### PR TITLE
chore(legal): complete provenance and license compliance audit

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,65 @@
+# Attribution and Modification Notice
+
+## DinoRPG Remastered
+
+DinoRPG Remastered is an independently maintained modified derivative that contains source code adapted from the open-source Eternaltwin DinoRPG project, together with material originating from Motion Twin's DinoRPG archives and new work created for DinoRPG Remastered.
+
+DinoRPG Remastered is not affiliated with, sponsored by, or endorsed by Eternaltwin or Motion Twin.
+
+## Eternaltwin DinoRPG
+
+Original project:
+
+https://gitlab.com/eternaltwin/dinorpg/dinorpg
+
+Reference revision used for the provenance audit:
+
+`3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d`
+
+License:
+
+GNU Affero General Public License version 3 or later (`AGPL-3.0-or-later`)
+
+Copyright in the original Eternaltwin contributions remains with their respective authors and contributors. No original copyright, authorship, warranty, or license notice is intentionally removed or replaced by this notice.
+
+## Modifications
+
+Eternaltwin-derived source files were subsequently modified, refactored, reorganized, or extended by the contributors to DinoRPG Remastered. Relevant modification dates are stated in file-level provenance notices and are also available in the Git history.
+
+The principal project-level changes include:
+
+- reorganization into `app/client`, `app/server`, and `packages/core`;
+- substantial backend development and adaptation around Fastify;
+- migration of monorepo tooling to pnpm;
+- changes and extensions to Prisma data models and persistence;
+- changes and extensions to shared models, combat systems, and the Vue client;
+- additional dialogs, scenarios, administration tools, deployment tooling, documentation, localization, and infrastructure;
+- new source code and features created specifically for DinoRPG Remastered.
+
+## Motion Twin material
+
+Some game assets, data, names, text, and historical source material originate from Motion Twin's WebGamesArchives:
+
+https://github.com/motion-twin/WebGamesArchives/tree/main/DinoRPG
+
+Such material remains subject to the attribution and licensing terms applicable to the corresponding Motion Twin archive material, including CC BY-NC-SA 4.0 where indicated.
+
+## Contributor context
+
+Matthieu Bonjour, maintainer of DinoRPG Remastered, previously contributed to the Eternaltwin DinoRPG project. His public contribution history is available here:
+
+https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/commits/staging?author=Matthieu%20Bonjour
+
+This information is provided as context and as part of DinoCore Labs' good-faith effort to document provenance and preserve the rights and attribution of all contributors.
+
+## Source-code license
+
+The source code covered by this repository's GNU AGPL license is distributed under GNU AGPL version 3 or later.
+
+SPDX identifier:
+
+`AGPL-3.0-or-later`
+
+See `LICENSE` for the complete license text.
+
+This notice supplements and does not replace any file-level or upstream copyright, authorship, warranty, or license notice.

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -63,3 +63,21 @@ SPDX identifier:
 See `LICENSE` for the complete license text.
 
 This notice supplements and does not replace any file-level or upstream copyright, authorship, warranty, or license notice.
+
+## Ruffle
+
+DinoRPG Remastered includes a self-hosted web distribution of Ruffle,
+a Flash Player emulator developed by the Ruffle contributors.
+
+- Component: Ruffle
+- Package: `@ruffle-rs/ruffle`
+- Version: `0.2.0-nightly.2025.11.29`
+- Upstream project: https://github.com/ruffle-rs/ruffle
+- Local distribution: `app/client/public/ruffle/`
+- License: MIT OR Apache-2.0, at the recipient's option
+- Apache-2.0 license text: `app/client/public/ruffle/LICENSE_APACHE`
+- MIT license text: `app/client/public/ruffle/LICENSE_MIT`
+
+Ruffle remains licensed under its own license terms and is not relicensed
+under the GNU Affero General Public License applicable to DinoRPG
+Remastered source code.

--- a/app/client/index.html
+++ b/app/client/index.html
@@ -1,4 +1,17 @@
 <!doctype html>
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/index.html
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-16 through 2026-06-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <html lang="fr">
 	<head>
 		<meta charset="UTF-8" />

--- a/app/client/src/components/account/EpicRewardsCard.vue
+++ b/app/client/src/components/account/EpicRewardsCard.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/data/EpicRewards.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="profil">
 		<h3>

--- a/app/client/src/components/account/GoalsCard.vue
+++ b/app/client/src/components/account/GoalsCard.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/data/TwinoidGoals.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-02-18.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template class="twinoid-goals">
 	<div class="profil">
 		<img class="headProfil" :src="getImgURL('background', 'ugoals_crown')" alt="info_button" />

--- a/app/client/src/components/account/MyDinoz.vue
+++ b/app/client/src/components/account/MyDinoz.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/data/MyDinoz.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dinozFilters">
 		<label class="filter">

--- a/app/client/src/components/account/ProfileGame.vue
+++ b/app/client/src/components/account/ProfileGame.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/data/Profile.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<transition name="fade">
 		<div class="profil" v-if="!option">

--- a/app/client/src/components/clan/ClanCreatePage.vue
+++ b/app/client/src/components/clan/ClanCreatePage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanCreatePage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="page">
 		<h3>{{ editMode ? $t('clan.clanPages.creation.edit') : $t('clan.clanPages.creation.new') }}</h3>

--- a/app/client/src/components/clan/ClanDiscussion.vue
+++ b/app/client/src/components/clan/ClanDiscussion.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanDiscussion.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-29 through 2026-07-17.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="new-message-container" v-if="hasAccess">
 		<template v-if="!showEditor">

--- a/app/client/src/components/clan/ClanHeader.vue
+++ b/app/client/src/components/clan/ClanHeader.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanHeader.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dz-box header">
 		<h3>

--- a/app/client/src/components/clan/ClanHistory.vue
+++ b/app/client/src/components/clan/ClanHistory.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanHistory.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="hasAccess" class="wrapper">
 		<div class="history-container" v-for="evt in history" :key="evt.id">

--- a/app/client/src/components/clan/ClanMemberEdit.vue
+++ b/app/client/src/components/clan/ClanMemberEdit.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanMemberEdit.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-01.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="wrapper">
 		<DZDisclaimer

--- a/app/client/src/components/clan/ClanMembers.vue
+++ b/app/client/src/components/clan/ClanMembers.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanMembers.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-06-29.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="wrapper">
 		<div class="requests-container" v-if="joinRequestsList && joinRequestsList.length > 0 && selfMember">

--- a/app/client/src/components/clan/ClanPage.vue
+++ b/app/client/src/components/clan/ClanPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="page">
 		<p style="white-space: pre-line; word-break: break-word">{{ page.content }}</p>

--- a/app/client/src/components/clan/ClanPages.vue
+++ b/app/client/src/components/clan/ClanPages.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanPages.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="wrapper">
 		<div class="pages-titles-container">

--- a/app/client/src/components/clan/ClanParameters.vue
+++ b/app/client/src/components/clan/ClanParameters.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanParameters.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-01.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="hasAccess" class="wrapper">
 		<div class="banner-panel dz-box" v-if="hasBannerEditRight">

--- a/app/client/src/components/clan/ClanTreasure.vue
+++ b/app/client/src/components/clan/ClanTreasure.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/ClanTreasure.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="wrapper">
 		<DZDisclaimer round help :content="$t('clan.ingredients.help', { value: treasureValue })" />

--- a/app/client/src/components/clan/LangSelector.vue
+++ b/app/client/src/components/clan/LangSelector.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/clans/LangSelector.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="flags">
 		<Flag

--- a/app/client/src/components/common/DetailsTab.vue
+++ b/app/client/src/components/common/DetailsTab.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DetailsTab.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-03.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="details">
 		<!--<DZSelect

--- a/app/client/src/components/common/Footer.vue
+++ b/app/client/src/components/common/Footer.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/Footer.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-21 through 2026-07-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<footer>
 		<div class="wrapper">

--- a/app/client/src/components/common/InventoryTab.vue
+++ b/app/client/src/components/common/InventoryTab.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/InventoryTab.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-08.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="inventory">
 		<p class="wrapperMenu" @click="hidden = !hidden">{{ $t('dinozPage.inventory.sortBy') }}</p>

--- a/app/client/src/components/common/LeftPanel.vue
+++ b/app/client/src/components/common/LeftPanel.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/LeftPanel.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-21 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div id="accountList">
 		<div class="money">

--- a/app/client/src/components/common/MapTab.vue
+++ b/app/client/src/components/common/MapTab.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/MapTab.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div id="boxMap">
 		<WorldMap :dinozData="dinozData" :key="dinozData.borderPlace[0]" />

--- a/app/client/src/components/common/Poll.vue
+++ b/app/client/src/components/common/Poll.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/Poll.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-03-22.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="poll-container">
 		<div class="poll-title">

--- a/app/client/src/components/common/Roadmap.vue
+++ b/app/client/src/components/common/Roadmap.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/Roadmap.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-03-04 through 2026-07-31.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="roadmap">
 		<h3>{{ $t('newsPage.roadmap.title') }}</h3>

--- a/app/client/src/components/common/TabPanels.vue
+++ b/app/client/src/components/common/TabPanels.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/TabPanel.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="tabPanel">
 		<ul class="tabs">

--- a/app/client/src/components/common/WorldMap.vue
+++ b/app/client/src/components/common/WorldMap.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/WorldMap.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div
 		class="map_container"

--- a/app/client/src/components/dinoz/DinozActions.vue
+++ b/app/client/src/components/dinoz/DinozActions.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozActions.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="actions">
 		<Resurrect :enabled="resurrect" @close="resurrect = false" />

--- a/app/client/src/components/dinoz/DinozAnimation.vue
+++ b/app/client/src/components/dinoz/DinozAnimation.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozWithoutFlash.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<img v-if="loaded" :src="dinoImg" />
 </template>

--- a/app/client/src/components/dinoz/DinozBars.vue
+++ b/app/client/src/components/dinoz/DinozBars.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozBars.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dinozBars" v-if="dinozData">
 		<div

--- a/app/client/src/components/dinoz/DinozDisplay.vue
+++ b/app/client/src/components/dinoz/DinozDisplay.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozDisplay.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-06-07.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dinoz">
 		<TitleHeader :title="$t('pageTitle.dinoz', { dinoz: dinozData.name })" />

--- a/app/client/src/components/dinoz/DinozElements.vue
+++ b/app/client/src/components/dinoz/DinozElements.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozElements.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="elements_div">
 		<p>{{ $t('dinozPage.elements') }}</p>

--- a/app/client/src/components/dinoz/DinozEquip.vue
+++ b/app/client/src/components/dinoz/DinozEquip.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozEquip.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-08.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="equip">
 		<template v-for="(item, index) in items" :key="index">

--- a/app/client/src/components/dinoz/DinozList.vue
+++ b/app/client/src/components/dinoz/DinozList.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozList.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<ul>
 		<li

--- a/app/client/src/components/dinoz/DinozMini.vue
+++ b/app/client/src/components/dinoz/DinozMini.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozMini.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div ref="dino" class="dinoWrap" />
 </template>

--- a/app/client/src/components/dinoz/DinozName.vue
+++ b/app/client/src/components/dinoz/DinozName.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/ChooseDinozName.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-10.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="`${$t('pageTitle.dinozNaming')}`" :header="$t(`dinozPage.chooseDinoz.pageName`)"></TitleHeader>
 	<DZDisclaimer help round content="dinozPage.chooseDinoz.information" />

--- a/app/client/src/components/dinoz/DinozStatus.vue
+++ b/app/client/src/components/dinoz/DinozStatus.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DinozStatus.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="fx" @click="displayStatus = !displayStatus">
 		<p>{{ $t('dinozPage.fx') }}</p>

--- a/app/client/src/components/dinoz/Elements.vue
+++ b/app/client/src/components/dinoz/Elements.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/data/Elements.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-02-18.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="element">
 		<div

--- a/app/client/src/components/dinoz/LevelUpGrid.vue
+++ b/app/client/src/components/dinoz/LevelUpGrid.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/LevelUpGrid.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-17 through 2026-05-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="container" ref="grid">
 		<template v-for="(cell, index) in levelUpGrid" :key="index">

--- a/app/client/src/components/dinoz/SkillTooltip.vue
+++ b/app/client/src/components/dinoz/SkillTooltip.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/SkillTooltip.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Tippy theme="normal">
 		<slot />

--- a/app/client/src/components/dinoz/SkillTree.vue
+++ b/app/client/src/components/dinoz/SkillTree.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/SkillTree.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-27 through 2026-06-07.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
 import { Tippy } from 'vue-tippy';

--- a/app/client/src/components/fight/FightBounce.vue
+++ b/app/client/src/components/fight/FightBounce.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/fight/FightBounce.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-18.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition name="bounce">
 		<div class="wrapper">

--- a/app/client/src/components/fight/FightHeader.vue
+++ b/app/client/src/components/fight/FightHeader.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/fight/FightersHeader.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-01.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="fighters-header" v-if="leftPlayer || rightPlayer">
 		<div class="player">

--- a/app/client/src/components/market/OfferHistory.vue
+++ b/app/client/src/components/market/OfferHistory.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/market/OfferHistory.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-05-10.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<DZDisclaimer help :content="$t('market.historyView.lastOffers')" />
 	<div class="df jcsb center">

--- a/app/client/src/components/market/OfferLine.vue
+++ b/app/client/src/components/market/OfferLine.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/market/OfferLine.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-10 through 2026-05-11.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<tr>
 		<td v-if="offer.dinoz" :data-dinoz-level="offer.dinoz.level" :class="{ dinoz: true, 'has-dinoz': !!offer.dinoz }">

--- a/app/client/src/components/market/OfferList.vue
+++ b/app/client/src/components/market/OfferList.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/market/OfferList.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-10 through 2026-05-10.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<DZDisclaimer help :content="$t('market.disclaimer')" />
 	<div class="header df aic jcsb center">

--- a/app/client/src/components/market/Sell.vue
+++ b/app/client/src/components/market/Sell.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/market/Sell.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-10 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<DZDisclaimer help :content="$t('market.sellView.disclaimer')" />
 	<h4>{{ $t('market.sellView.prepareYourOffer') }}</h4>

--- a/app/client/src/components/market/Transactions.vue
+++ b/app/client/src/components/market/Transactions.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/market/Transactions.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-10 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<template v-if="myExpiredOffers.length">
 		<h4>{{ $t('market.transactionView.myExpiredOffers') }}</h4>

--- a/app/client/src/components/messaging/Message.vue
+++ b/app/client/src/components/messaging/Message.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/message/Message.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-17 through 2026-04-17.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="container">
 		<div class="sender">

--- a/app/client/src/components/messaging/Thread.vue
+++ b/app/client/src/components/messaging/Thread.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/message/Thread.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-17 through 2026-05-04.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div id="threadPannel">
 		<div class="title">

--- a/app/client/src/components/modal/GatherRewardModal.vue
+++ b/app/client/src/components/modal/GatherRewardModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/GatherRewardModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition>
 		<div class="modal-background">

--- a/app/client/src/components/modal/Messaging.vue
+++ b/app/client/src/components/modal/Messaging.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/MessagerieModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-17 through 2026-06-15.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<dialog ref="messageRef">
 		<div class="modal">

--- a/app/client/src/components/modal/MissionInformationModal.vue
+++ b/app/client/src/components/modal/MissionInformationModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/MissionInformationModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-13 through 2026-05-03.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition>
 		<div v-if="enabled && mission" class="modal-background">

--- a/app/client/src/components/modal/MissionRewardModal.vue
+++ b/app/client/src/components/modal/MissionRewardModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/MissionRewardModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-13 through 2026-05-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition>
 		<div v-if="textKey" class="modal-background" @click="$emit('close')">

--- a/app/client/src/components/modal/MissionTalkModal.vue
+++ b/app/client/src/components/modal/MissionTalkModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/NPCModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-13 through 2026-04-20.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition>
 		<div v-if="textKey" class="modal-background" @click="$emit('close')">

--- a/app/client/src/components/modal/ReincarnateModal.vue
+++ b/app/client/src/components/modal/ReincarnateModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/ResurrectModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-25 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="enabled" class="modal-background">
 		<div class="modal-box">

--- a/app/client/src/components/modal/ResurrectModal.vue
+++ b/app/client/src/components/modal/ResurrectModal.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/ResurrectModal.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-25 through 2026-05-08.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="enabled" class="modal-background">
 		<div class="modal-box">

--- a/app/client/src/components/modal/UserCard.vue
+++ b/app/client/src/components/modal/UserCard.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/modal/PlayerMenu.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="user-card" v-if="loadedUser">
 		<RouterLink class="playerLink" :to="getProfileRoute(loadedUser.id)">

--- a/app/client/src/components/rankings/CompletionRanking.vue
+++ b/app/client/src/components/rankings/CompletionRanking.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/rankings/CompletionRanking.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-02-15.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<DZDisclaimer content="ranking.disclaimer.completion" />
 	<div class="wrapper">

--- a/app/client/src/components/rankings/PlayerRanking.vue
+++ b/app/client/src/components/rankings/PlayerRanking.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/rankings/PlayerRanking.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-08-04.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<DZDisclaimer content="ranking.disclaimer.classic" help v-if="sort === 'classic'" />
 	<DZDisclaimer content="ranking.disclaimer.average" help v-if="sort === 'average'" />

--- a/app/client/src/components/tools/LeftUserMenu.vue
+++ b/app/client/src/components/tools/LeftUserMenu.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/toolBar/DinozLeftMenu.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-25 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition name="opacity">
 		<div v-show="menuCalled" class="backDrop" @click="close()"></div>

--- a/app/client/src/components/tools/TopBar.vue
+++ b/app/client/src/components/tools/TopBar.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/toolBar/TopBar.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-21 through 2026-04-18.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div id="topBar">
 		<div class="boxRoot">

--- a/app/client/src/components/tools/UserMenu.vue
+++ b/app/client/src/components/tools/UserMenu.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/toolBar/TwinoRightMenu.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-28 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition name="opacity">
 		<div v-show="menuCalled" class="backDrop" @click="close()"></div>

--- a/app/client/src/components/utils/DZCheckbox.vue
+++ b/app/client/src/components/utils/DZCheckbox.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZCheckbox.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-03-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dz-checkbox" :class="{ disabled }">
 		<input type="checkbox" :id="id" :name="id" :disabled="disabled" :checked="isChecked" @change="onChange" />

--- a/app/client/src/components/utils/DZConfirmDialog.vue
+++ b/app/client/src/components/utils/DZConfirmDialog.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/confirmDialog.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="visible" class="simple-confirm-dialog-mask" @click="rejectDialog">
 		<div class="simple-confirm-dialog dz-box" @click.stop>

--- a/app/client/src/components/utils/DZDisclaimer.vue
+++ b/app/client/src/components/utils/DZDisclaimer.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZDisclaimer.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2025-12-02.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div :class="['disclaimer', { round }]">
 		<img v-if="help" :src="getImgURL('icons', 'question', true)" class="icon" />

--- a/app/client/src/components/utils/DZFollow.vue
+++ b/app/client/src/components/utils/DZFollow.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/dinoz/DZFollow.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Tippy v-if="!display" class="action" tag="div" id="act_follow" theme="normal" @click="displayFollow()">
 		<img class="arrow" :src="getImgURL('act', 'act_follow')" alt="act_follow" />

--- a/app/client/src/components/utils/DZInput.vue
+++ b/app/client/src/components/utils/DZInput.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZInput.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<input :type="type" :value="modelValue ?? value" @input="onInput" v-bind="$attrs" />
 </template>

--- a/app/client/src/components/utils/DZLocale.vue
+++ b/app/client/src/components/utils/DZLocale.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/LocaleChange.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-18 through 2026-05-06.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="locale-wrapper">
 		<button class="locale-btn" @click="isOpen = !isOpen">

--- a/app/client/src/components/utils/DZRadio.vue
+++ b/app/client/src/components/utils/DZRadio.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZRadio.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-03-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dz-radio" :class="{ disabled }">
 		<input

--- a/app/client/src/components/utils/DZSelect.vue
+++ b/app/client/src/components/utils/DZSelect.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZSelect.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-03-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="dz-select" :class="{ open, searchable: !!search }">
 		<button

--- a/app/client/src/components/utils/DZTable.vue
+++ b/app/client/src/components/utils/DZTable.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZTable.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-01-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<table>
 		<tbody>

--- a/app/client/src/components/utils/DZUser.vue
+++ b/app/client/src/components/utils/DZUser.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/DZUser.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="user-container">
 		<span

--- a/app/client/src/components/utils/Flag.vue
+++ b/app/client/src/components/utils/Flag.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/Flag.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-04-18.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<img :src="getImgURL('lang', `lang_${lang}`)" class="flag" />
 </template>

--- a/app/client/src/components/utils/Loading.vue
+++ b/app/client/src/components/utils/Loading.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/Loading.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-04-26.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <script lang="ts">
 import { defineComponent } from 'vue';
 

--- a/app/client/src/components/utils/Spinner.vue
+++ b/app/client/src/components/utils/Spinner.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/Spinner.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors on 2026-04-26.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
 import { useLoadingStore } from '../../store/loadingStore';

--- a/app/client/src/components/utils/TitleHeader.vue
+++ b/app/client/src/components/utils/TitleHeader.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/TitleHeader.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-01-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="section" v-if="header">
 		<h2 class="titlePage" v-html="header"></h2>

--- a/app/client/src/components/utils/Toast.vue
+++ b/app/client/src/components/utils/Toast.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/utils/Toast.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-01-20.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<Transition>
 		<div v-if="displayToast" class="snackbar" @click="displayToast = !displayToast">

--- a/app/client/src/constants/dinozPlacement.ts
+++ b/app/client/src/constants/dinozPlacement.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/constants/dinozPlacement.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const dinozPlacement: Placement = {
 	noFliped: {
 		0: {

--- a/app/client/src/constants/place.ts
+++ b/app/client/src/constants/place.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/constants/place.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { MapZone } from '@dinorpg/core/models/enums/MapZone.js';
 import { PlaceIcon } from '@dinorpg/core/models/enums/PlaceIcon.js';
 import type { PlaceDisplayed } from '@dinorpg/core/models/place/placeDisplayed.js';

--- a/app/client/src/constants/race.ts
+++ b/app/client/src/constants/race.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/constants/race.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const raceList: Record<number, string> = {
 	1: 'moueffe',
 	2: 'moueffe_demon',

--- a/app/client/src/constants/shop.ts
+++ b/app/client/src/constants/shop.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/constants/shop.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-28.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const shopNameList: Array<string> = [
 	'unknown',
 	'flying',

--- a/app/client/src/constants/status.ts
+++ b/app/client/src/constants/status.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/constants/status.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-26.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';
 
 export const statusList: {

--- a/app/client/src/fight/translateFightStep.ts
+++ b/app/client/src/fight/translateFightStep.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/utils/translateFightStep.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementNames } from '@dinorpg/core/models/enums/ElementType.js';
 import { SkillVisualEffect } from '@dinorpg/core/models/enums/SkillVisualEffect.js';
 import { FighterType } from '@dinorpg/core/models/fight/fighterType.js';

--- a/app/client/src/fight/transpileFight.ts
+++ b/app/client/src/fight/transpileFight.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/utils/transpileFight.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { GroundEnum } from '@dinorpg/core/models/enums/GroundEnum.js';
 import { SkillVisualEffect } from '@dinorpg/core/models/enums/SkillVisualEffect.js';

--- a/app/client/src/i18n/index.ts
+++ b/app/client/src/i18n/index.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/i18n/index.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-04-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Language } from '@dinorpg/core/models/config/language.js';
 import { createI18n, type I18n } from 'vue-i18n';
 

--- a/app/client/src/main.ts
+++ b/app/client/src/main.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/main.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-11-16 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import './style/main.scss';
 
 import { createPinia } from 'pinia';

--- a/app/client/src/pages/Clan/Clan.vue
+++ b/app/client/src/pages/Clan/Clan.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Clan/Clan.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader
 		v-if="clanStore.getClan"

--- a/app/client/src/pages/Clan/ClanJoinRequest.vue
+++ b/app/client/src/pages/Clan/ClanJoinRequest.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Clan/ClanJoinRequest.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div v-if="joinRequest" class="join-request">
 		<p class="request-text">

--- a/app/client/src/pages/Clan/ClanList.vue
+++ b/app/client/src/pages/Clan/ClanList.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Clan/ClansList.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-23.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.clansList')" :header="$t('clansList.title')"></TitleHeader>
 	<DZDisclaimer help round :content="$t('clansList.disclaimer.text')" />

--- a/app/client/src/pages/Clan/CreateClan.vue
+++ b/app/client/src/pages/Clan/CreateClan.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Clan/CreateClan.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.createClan')" :header="$t('createClan.title')"></TitleHeader>
 	<div id="chooseClanName">

--- a/app/client/src/pages/DinozPage.vue
+++ b/app/client/src/pages/DinozPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/DinozPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-30.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<template v-if="nameChoosen === false">
 		<DinozName :dinozData="dinozData" @setNameChoosen="setNameChoosen" />

--- a/app/client/src/pages/FAQPage.vue
+++ b/app/client/src/pages/FAQPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/FAQPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-01-25.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="`${$t('pageTitle.faq')}`" :header="$t(`topBar.userMenu.faq`)" />
 	<DZDisclaimer help round content="faq.intro" />

--- a/app/client/src/pages/FightPage.vue
+++ b/app/client/src/pages/FightPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Fight.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.fight')" :header="$t(`fight.pageName`)" />
 	<div v-if="loaded && fightTransformed?.history?.length" class="content">

--- a/app/client/src/pages/ForcebrutPage.vue
+++ b/app/client/src/pages/ForcebrutPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/ForceBrute.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-13 through 2026-05-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.fb_tournament')" :header="$t('fb_tournament.title')" />
 	<DZDisclaimer help round :content="$t('fb_tournament.disclaimer')" />

--- a/app/client/src/pages/GatherPage.vue
+++ b/app/client/src/pages/GatherPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/GatherPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-04-01.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader
 		:title="$t('pageTitle.gather', { type: $t(`gather.action.${gatherType}`) })"

--- a/app/client/src/pages/HelpPage.vue
+++ b/app/client/src/pages/HelpPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/HelpPage.vue
+
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+
+  Modified by DinoRPG Remastered contributors from 2026-01-25 through 2026-07-01.
+  See NOTICE.md and the Git history for provenance and modification details.
+
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="`${$t('pageTitle.guide')}`" :header="$t('guide.title')" :sub-header="selectedItem?.name ?? ''" />
 	<div class="intro">
@@ -51,7 +64,6 @@
 				<img :src="getImgURL('icons', 'small_page_down')" />
 				{{ nextItemName }}
 			</button>
-
 			<button @click="goToPage('News')" class="next">
 				<img :src="getImgURL('icons', 'small_delete')" />
 				{{ $t(`guide.text.stop`) }}

--- a/app/client/src/pages/Ingredients.vue
+++ b/app/client/src/pages/Ingredients.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Ingredients.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-06-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.ingredients')" :header="$t(`topBar.userMenu.ingredients`)" />
 	<DZDisclaimer help round content="ingredients.disclaimer" />

--- a/app/client/src/pages/LevelUpPage.vue
+++ b/app/client/src/pages/LevelUpPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/LevelUp.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-17 through 2026-06-07.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader
 		v-if="availableSkills"

--- a/app/client/src/pages/MainPage.vue
+++ b/app/client/src/pages/MainPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/MainPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2025-11-21 through 2026-03-22.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<div class="mainpage">
 		<div class="mainpage-header">

--- a/app/client/src/pages/ManageDinoz.vue
+++ b/app/client/src/pages/ManageDinoz.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/ManageDinoz.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-02 through 2026-05-13.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.manageDinoz')" :header="$t('manageDinoz.title')" />
 	<DZDisclaimer :content="$t('manageDinoz.disclaimer')" />

--- a/app/client/src/pages/MarketPage.vue
+++ b/app/client/src/pages/MarketPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/MarketPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-05-10 through 2026-05-27.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.market')" :header="$t('market.title')" />
 	<div class="tabPanel">

--- a/app/client/src/pages/MissionsPage.vue
+++ b/app/client/src/pages/MissionsPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/Missions.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-04-13 through 2026-05-03.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="`${$t('pageTitle.missions')}`" :header="formatContent($t(`missions.header`))" />
 	<DZTable>

--- a/app/client/src/pages/NewsPage.vue
+++ b/app/client/src/pages/NewsPage.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/components/common/News.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-03-04 through 2026-04-26.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="`${$t('pageTitle.news')}`" :header="$t('newsPage.title')"></TitleHeader>
 	<div v-for="news in batch" :key="news.id" :class="news.hide ? 'bloc hide' : 'bloc'" @click="toggleCollapse(news)">

--- a/app/client/src/pages/ShopDinoz.vue
+++ b/app/client/src/pages/ShopDinoz.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/DinozShopPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors on 2026-02-09.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.dinozShop')" :header="$t(`shop.dinoz.header`)" />
 	<DZDisclaimer help round :content="$t('shop.dinoz.help')" />

--- a/app/client/src/pages/ShopItems.vue
+++ b/app/client/src/pages/ShopItems.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/ItemShopPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-28 through 2026-07-31.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader
 		v-if="actualShop"

--- a/app/client/src/pages/ShopItinerant.vue
+++ b/app/client/src/pages/ShopItinerant.vue
@@ -1,3 +1,16 @@
+<!--
+  This file contains code derived from or adapted from:
+  Eternaltwin DinoRPG
+  Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/pages/ItinerantMerchantPage.vue
+  
+  Copyright in the original contributions remains with the respective
+  authors and contributors.
+  
+  Modified by DinoRPG Remastered contributors from 2026-02-28 through 2026-06-03.
+  See NOTICE.md and the Git history for provenance and modification details.
+  
+  SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 <template>
 	<TitleHeader :title="$t('pageTitle.itinerant')" :header="formatContent($t(`shop.item.merchant.name`))" />
 	<div class="shop">

--- a/app/client/src/shims-vue.d.ts
+++ b/app/client/src/shims-vue.d.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/shims-vue.d.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-05-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 /* eslint-disable */
 declare module '*.vue' {
 	import type { DefineComponent } from 'vue';

--- a/app/client/src/store/clanStore.ts
+++ b/app/client/src/store/clanStore.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/store/clanStore.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-07-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Language } from '@dinorpg/core/models/config/language.js';
 import type { ClanStore } from '@dinorpg/core/models/store/clanStore.js';
 import { defineStore } from 'pinia';

--- a/app/client/src/store/sessionStore.ts
+++ b/app/client/src/store/sessionStore.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/store/sessionStore.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import type { FightResult } from '@dinorpg/core/models/fight/fightResult.js';
 import type { StateSessionStore } from '@dinorpg/core/models/store/stateSessionStore.js';
 import { defineStore } from 'pinia';

--- a/app/client/src/style/components/_vtippy.scss
+++ b/app/client/src/style/components/_vtippy.scss
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/css/_tooltip.scss
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 .tippy-box[data-theme~='small'] {
 	background-color: #bc683c;
 	outline: 2px solid #86401e;

--- a/app/client/src/utils/confirmPlugin.ts
+++ b/app/client/src/utils/confirmPlugin.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/mixin/confirmPlugin.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { type App, createVNode, reactive, render } from 'vue';
 
 import DZConfirmDialog from '../components/utils/DZConfirmDialog.vue';

--- a/app/client/src/utils/formatText.ts
+++ b/app/client/src/utils/formatText.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/utils/formatText.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-05-10.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { getImgURL } from './getImgURL';
 
 export const helpers = {

--- a/app/client/src/utils/goTo.ts
+++ b/app/client/src/utils/goTo.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-ui/src/utils/goTo.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import type { RouteLocationNamedRaw, Router } from 'vue-router';
 
 export const goTo = (router: Router, page: string, props?: RouteLocationNamedRaw) => {

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -1,3 +1,19 @@
+// This file contains code derived from or adapted from:
+// Eternaltwin DinoRPG
+// Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/prisma/schema.prisma
+//
+// Copyright in the original contributions remains with the respective
+// authors and contributors.
+//
+// Modified by DinoRPG Remastered contributors.
+// Modifications include substantial expansion and restructuring of the
+// database schema, models, relations, identifiers, indexes, constraints,
+// and game systems.
+//
+// See NOTICE.md and the Git history for provenance and modification details.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 generator client {
   provider        = "prisma-client-js"
   output          = "../../prisma"

--- a/app/server/src/Dinoz/Controller/dinozCatches.controller.ts
+++ b/app/server/src/Dinoz/Controller/dinozCatches.controller.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/dao/dinozCatchDao.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-03-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Monster } from '@dinorpg/core/models/monster/monsterList.js';
 
 import { prisma } from '../../prisma.js';

--- a/app/server/src/Dinoz/Controller/dinozStatus.controller.ts
+++ b/app/server/src/Dinoz/Controller/dinozStatus.controller.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/dao/dinozStatusDao.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { prisma } from '../../prisma.js';
 
 export async function addStatusToDinoz(dinozId: number, statusId: number) {

--- a/app/server/src/Fight/Service/fight.service.ts
+++ b/app/server/src/Fight/Service/fight.service.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/business/fightService.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozItems } from '@dinorpg/core/models/dinoz/dinozItems.js';
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';
 import { ItemType } from '@dinorpg/core/models/enums/ItemType.js';

--- a/app/server/src/Inventory/Controller/removeItemFromDinoz.controller.ts
+++ b/app/server/src/Inventory/Controller/removeItemFromDinoz.controller.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/dao/dinozItemDao.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { prisma } from '../../prisma.js';
 
 export async function removeItemFromDinoz(dinozId: number, itemId: number) {

--- a/app/server/src/Level/Controller/removeUnlockableSkillsFromDinoz.ts
+++ b/app/server/src/Level/Controller/removeUnlockableSkillsFromDinoz.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/dao/dinozSkillUnlockableDao.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-17 through 2026-02-17.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { prisma } from '../../prisma.js';
 
 export async function removeUnlockableSkillsFromDinoz(dinozId: number, skillId: number[] /*event?: GameDinozUsage*/) {

--- a/app/server/src/utils/dinoz/level.mapper.ts
+++ b/app/server/src/utils/dinoz/level.mapper.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/dinoz.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-17 through 2026-05-27.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozRace } from '@dinorpg/core/models/dinoz/dinozRace.js';
 import { raceList } from '@dinorpg/core/models/dinoz/raceList.js';
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';

--- a/app/server/src/utils/dinoz/skillParser.ts
+++ b/app/server/src/utils/dinoz/skillParser.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/skillParser.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-17 through 2026-02-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Stat } from '@dinorpg/core/models/enums/SkillStat.js';
 import { EffectDescriptor, PassiveEffects, SkillDetails } from '@dinorpg/core/models/skills/skillDetails.js';
 import { Skill, uSkillsToPlayerFieldMap } from '@dinorpg/core/models/skills/skillList.js';

--- a/app/server/src/utils/fight/fight.mapper.ts
+++ b/app/server/src/utils/fight/fight.mapper.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/FightConfiguration.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-03-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { PlaceEnum } from '@dinorpg/core/models/enums/PlaceEnum.js';
 import { DetailedFighter } from '@dinorpg/core/models/fight/detailedFighter.js';
 

--- a/app/server/src/utils/fight/fightMethods.ts
+++ b/app/server/src/utils/fight/fightMethods.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/fightMethods.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { SkillType } from '@dinorpg/core/models/enums/SkillType.js';

--- a/app/server/src/utils/fight/generateFight.ts
+++ b/app/server/src/utils/fight/generateFight.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/generateFight.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-30.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { ItemType } from '@dinorpg/core/models/enums/ItemType.js';

--- a/app/server/src/utils/fight/getDamage.ts
+++ b/app/server/src/utils/fight/getDamage.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/getDamage.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { DetailedFighter } from '@dinorpg/core/models/fight/detailedFighter.js';
 import { FighterType } from '@dinorpg/core/models/fight/fighterType.js';

--- a/app/server/src/utils/fight/getFighters.ts
+++ b/app/server/src/utils/fight/getFighters.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/getFighters.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '@dinorpg/core/models/dinoz/statusList.js';
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { MapZone } from '@dinorpg/core/models/enums/MapZone.js';

--- a/app/server/src/utils/fight/monsterBonuses.ts
+++ b/app/server/src/utils/fight/monsterBonuses.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/monsterBonuses.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '@dinorpg/core/models/enums/ElementType.js';
 import { DetailedFighter } from '@dinorpg/core/models/fight/detailedFighter.js';
 import { FightStatus } from '@dinorpg/core/models/fight/fightStatus.js';

--- a/app/server/src/utils/fight/skillFightConditionParser.ts
+++ b/app/server/src/utils/fight/skillFightConditionParser.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/skillFightConditionParser.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Operator } from '@dinorpg/core/models/enums/Parser.js';
 import { DetailedFighter } from '@dinorpg/core/models/fight/detailedFighter.js';
 import { BadFightStatus, GoodFightStatus } from '@dinorpg/core/models/fight/fightStatus.js';

--- a/app/server/src/utils/fight/weightedRandom.ts
+++ b/app/server/src/utils/fight/weightedRandom.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/fight/weightedRandom.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 const weightedRandom = <T extends { odds: number }>(items: T[]) => {
 	const totalOdds = items.reduce((acc, item) => acc + item.odds, 0);
 	if (totalOdds === 0) {

--- a/app/server/src/utils/user/calculatePlayerCompletion.ts
+++ b/app/server/src/utils/user/calculatePlayerCompletion.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/utils/boxesLogic.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-05-18.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
 
 import gameConfig from '../../config/game.config.js';

--- a/packages/core/src/models/admin/adminSecrets.ts
+++ b/packages/core/src/models/admin/adminSecrets.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/admin/SecretData.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-03-14 through 2026-03-14.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export interface AdminSecret {
 	key: string;
 	value: string;

--- a/packages/core/src/models/clan/clan.ts
+++ b/packages/core/src/models/clan/clan.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/clan/clan.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-06-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Language } from '@dinorpg/core/models/config/language.js';
 
 import { UserData } from '../user/userData.js';

--- a/packages/core/src/models/clan/clanHistory.ts
+++ b/packages/core/src/models/clan/clanHistory.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/clan/clanHistory.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-06-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ClanHistoryType } from '../enums/ClanHistoryType.js';
 
 export interface ClanHistory {

--- a/packages/core/src/models/clan/clanJoinRequest.ts
+++ b/packages/core/src/models/clan/clanJoinRequest.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/clan/clanJoinRequest.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-06-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { UserData } from '../user/userData.js';
 import { UserToolTip } from '../user/userToolTip.js';
 import { Clan } from './clan.js';

--- a/packages/core/src/models/clan/clanMember.ts
+++ b/packages/core/src/models/clan/clanMember.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/clan/clanMember.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-06-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import type { UserToolTip } from '../user/userToolTip.js';
 
 export interface ClanMember {

--- a/packages/core/src/models/clan/clanMessage.ts
+++ b/packages/core/src/models/clan/clanMessage.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/clan/clanMessage.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-06-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Clan } from './clan.js';
 
 export interface ClanMessageAuthor {

--- a/packages/core/src/models/dinoz/digTreasure.ts
+++ b/packages/core/src/models/dinoz/digTreasure.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/DigData.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-04-04 through 2026-05-08.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Condition } from '../conditions/conditions.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';
 import { DinozStatusId } from './statusList.js';

--- a/packages/core/src/models/dinoz/dinozActions.ts
+++ b/packages/core/src/models/dinoz/dinozActions.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/ActionList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { GatherType } from '../enums/GatherType.js';
 
 export enum Action {

--- a/packages/core/src/models/dinoz/dinozFiche.ts
+++ b/packages/core/src/models/dinoz/dinozFiche.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/DinozFiche.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-06.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozCurrentMission } from '../missions/missionCurrent.js';
 import { ActionFiche } from './dinozActions.js';
 import { DinozRace } from './dinozRace.js';

--- a/packages/core/src/models/dinoz/dinozItems.ts
+++ b/packages/core/src/models/dinoz/dinozItems.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/DinozItems.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-08.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export type EquipItemResponse = {
 	items: DinozItems[];
 	refreshDinoz: boolean;

--- a/packages/core/src/models/dinoz/dinozRace.ts
+++ b/packages/core/src/models/dinoz/dinozRace.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/DinozRace.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { RaceEnum } from '../enums/Race.js';
 
 export interface DinozRace {

--- a/packages/core/src/models/dinoz/raceList.ts
+++ b/packages/core/src/models/dinoz/raceList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/RaceList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { RaceEnum } from '../enums/Race.js';
 import { Skill } from '../skills/skillList.js';
 import { DinozRace } from './dinozRace.js';

--- a/packages/core/src/models/dinoz/statusList.ts
+++ b/packages/core/src/models/dinoz/statusList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/StatusList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum DinozStatusId {
 	BUOY = 1,
 	CLIMBING_GEAR = 2,

--- a/packages/core/src/models/enums/ClanHistoryType.ts
+++ b/packages/core/src/models/enums/ClanHistoryType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ClanHistoryType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-06-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ClanHistoryType {
 	CLAN_CREATED = 'CLAN_CREATED',
 	PLAYER_JOIN = 'PLAYER_JOIN',

--- a/packages/core/src/models/enums/ClanMemberRight.ts
+++ b/packages/core/src/models/enums/ClanMemberRight.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ClanMemberRight.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-06-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ClanMemberRight {
 	PAGE_MANAGE = 'PAGE_MANAGE',
 	MEMBER_ACCEPT_AND_DENY_REQUESTS = 'MEMBER_ACCEPT_AND_DENY_REQUESTS',

--- a/packages/core/src/models/enums/DayType.ts
+++ b/packages/core/src/models/enums/DayType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/dayEnum.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum DayEnum {
 	SUNDAY,
 	MONDAY,

--- a/packages/core/src/models/enums/ElementType.ts
+++ b/packages/core/src/models/enums/ElementType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ElementType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ElementType {
 	FIRE = 1,
 	WOOD = 2,

--- a/packages/core/src/models/enums/Energy.ts
+++ b/packages/core/src/models/enums/Energy.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/Energy.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum Energy {
 	E80 = 80,
 	E75 = 75,

--- a/packages/core/src/models/enums/FightType.ts
+++ b/packages/core/src/models/enums/FightType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/FightType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum FightType {
 	MONSTER_FIGHT = 1,
 	DINOZ_FIGHT = 2,

--- a/packages/core/src/models/enums/GatherType.ts
+++ b/packages/core/src/models/enums/GatherType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/GatherType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum GatherType {
 	FISH,
 	CUEILLE1,

--- a/packages/core/src/models/enums/GroundEnum.ts
+++ b/packages/core/src/models/enums/GroundEnum.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/GroundEnum.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum GroundEnum {
 	NONE,
 	DIRT,

--- a/packages/core/src/models/enums/ItemEffect.ts
+++ b/packages/core/src/models/enums/ItemEffect.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ItemEffect.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ItemEffect {
 	HEAL = 'heal',
 	RESURRECT = 'resurrect',

--- a/packages/core/src/models/enums/ItemType.ts
+++ b/packages/core/src/models/enums/ItemType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ItemType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ItemType {
 	CLASSIC = 'classic',
 	MAGICAL = 'magical',

--- a/packages/core/src/models/enums/MapZone.ts
+++ b/packages/core/src/models/enums/MapZone.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/MapZone.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum MapZone {
 	DINOLAND = 'zone_roydin',
 	DINOWEST = 'zone_dnwest2',

--- a/packages/core/src/models/enums/Parser.ts
+++ b/packages/core/src/models/enums/Parser.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/Parser.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ConditionEnum {
 	MINLEVEL = 'minlevel',
 	MAXLEVEL = 'maxlevel',

--- a/packages/core/src/models/enums/PlaceEnum.ts
+++ b/packages/core/src/models/enums/PlaceEnum.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/PlaceEnum.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum PlaceEnum {
 	ANYWHERE = 0,
 	PORT_DE_PRECHE = 1,

--- a/packages/core/src/models/enums/PlaceIcon.ts
+++ b/packages/core/src/models/enums/PlaceIcon.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/PlaceIcon.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum PlaceIcon {
 	CHURCH = 'church',
 	CASTLE = 'castle',

--- a/packages/core/src/models/enums/Race.ts
+++ b/packages/core/src/models/enums/Race.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/RaceEnum.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum RaceEnum {
 	MOUEFFE = 1,
 	MOUEFFE_DEMON = 2,

--- a/packages/core/src/models/enums/Services.ts
+++ b/packages/core/src/models/enums/Services.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ServiceEnum.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ServiceEnum {
 	CONCENTRATION = 'concentration',
 	DINOZ = 'dinoz',

--- a/packages/core/src/models/enums/ShopType.ts
+++ b/packages/core/src/models/enums/ShopType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/ShopType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-28.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum ShopType {
 	CLASSIC = 'classic',
 	MAGICAL = 'magical',

--- a/packages/core/src/models/enums/SkillStat.ts
+++ b/packages/core/src/models/enums/SkillStat.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/SkillStat.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum Stat {
 	MAX_HP = 'maxHp',
 	HP_REGEN = 'hpRegen',

--- a/packages/core/src/models/enums/SkillTreeType.ts
+++ b/packages/core/src/models/enums/SkillTreeType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/SkillTreeType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum SkillTreeType {
 	VANILLA = 'Original',
 	ETHER = 'Ether'

--- a/packages/core/src/models/enums/SkillType.ts
+++ b/packages/core/src/models/enums/SkillType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/SkillType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum SkillType {
 	E = 'E',
 	P = 'P',

--- a/packages/core/src/models/enums/SkillVisualEffect.ts
+++ b/packages/core/src/models/enums/SkillVisualEffect.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/SkillVisualEffect.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum SkillVisualEffect {
 	TODO,
 	FIREBALL,

--- a/packages/core/src/models/enums/StatsTracking.ts
+++ b/packages/core/src/models/enums/StatsTracking.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/enums/statTracking.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-05-11.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum StatTracking {
 	MOVES = 'moves',
 	DEATHS = 'deaths',

--- a/packages/core/src/models/enums/TemporaryStatus.ts
+++ b/packages/core/src/models/enums/TemporaryStatus.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/ed-be/src/constants/temporaryStatus.ts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-02-15.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum TemporaryStatus {
 	QWHY = 16,
 	QWOOD = 17,

--- a/packages/core/src/models/events/events.ts
+++ b/packages/core/src/models/events/events.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/event/Events.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export enum GameEvent {
 	CHRISTMAS = 'CHRISTMAS',
 	VALENTINE = 'VALENTINE'

--- a/packages/core/src/models/fight/detailedFighter.ts
+++ b/packages/core/src/models/fight/detailedFighter.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/DetailedFighter.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-03-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { ElementType } from '../enums/ElementType.js';
 import { ItemFiche } from '../items/itemFiche.js';

--- a/packages/core/src/models/fight/fightResult.ts
+++ b/packages/core/src/models/fight/fightResult.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/FightResult.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { ElementType } from '../enums/ElementType.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';

--- a/packages/core/src/models/fight/fightStatus.ts
+++ b/packages/core/src/models/fight/fightStatus.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/DetailedFighter.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { FIGHT_INFINITE } from '../../utils/fightConstants.js';
 
 export enum FightStatus {

--- a/packages/core/src/models/fight/fightStep.ts
+++ b/packages/core/src/models/fight/fightStep.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/FightStep.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { Item } from '../items/itemList.js';
 import { Boss } from '../monster/bossList.js';

--- a/packages/core/src/models/fight/transpiler.ts
+++ b/packages/core/src/models/fight/transpiler.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/transpiler.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2025-12-02 through 2026-03-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { SkillVisualEffect } from '../enums/SkillVisualEffect.js';
 

--- a/packages/core/src/models/gather/gatherDataV2.ts
+++ b/packages/core/src/models/gather/gatherDataV2.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/gather/gatherData.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Action } from '../dinoz/dinozActions.js';
 import { GatherType } from '../enums/GatherType.js';
 import { ItemFiche } from '../items/itemFiche.js';

--- a/packages/core/src/models/gather/gatherListV2.ts
+++ b/packages/core/src/models/gather/gatherListV2.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/gather/gatherList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Action } from '../dinoz/dinozActions.js';
 import { GatherType } from '../enums/GatherType.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';

--- a/packages/core/src/models/gather/gatherPublicGrid.ts
+++ b/packages/core/src/models/gather/gatherPublicGrid.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/gather/gatherPublicGrid.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-15.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export type GatherPublicGrid = {
 	grid: number[][];
 	gatherTurn: number;

--- a/packages/core/src/models/gather/gatherResult.ts
+++ b/packages/core/src/models/gather/gatherResult.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/gather/gatherResult.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-05-08.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { GatherRewards } from './gatherRewards.js';
 
 export type GatherIngredientInventoryState = {

--- a/packages/core/src/models/gather/gatherRewards.ts
+++ b/packages/core/src/models/gather/gatherRewards.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/gather/gatherRewards.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-15 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { IngredientFiche } from '../ingredients/ingredientFiche.js';
 import { ItemFicheDTO } from '../items/itemFiche.js';
 

--- a/packages/core/src/models/goals/goals.ts
+++ b/packages/core/src/models/goals/goals.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/goals/twinoidGoals.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { StatTracking } from '../enums/StatsTracking.js';
 import { Goal } from './goalsType.js';
 

--- a/packages/core/src/models/goals/goalsType.ts
+++ b/packages/core/src/models/goals/goalsType.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/goals/GoalsType.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { StatTracking } from '../enums/StatsTracking.js';
 
 declare const Languages: readonly ['EN', 'FR', 'DE', 'ES'];

--- a/packages/core/src/models/ingredients/ingredientFiche.ts
+++ b/packages/core/src/models/ingredients/ingredientFiche.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/ingredient/IngredientFiche.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Ingredient } from './ingredientList.js';
 
 export interface IngredientFiche {

--- a/packages/core/src/models/ingredients/ingredientList.ts
+++ b/packages/core/src/models/ingredients/ingredientList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/ingredient/ingredientList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-02-28.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { IngredientFiche } from './ingredientFiche.js';
 
 export enum Ingredient {

--- a/packages/core/src/models/ingredients/ingredientNameList.ts
+++ b/packages/core/src/models/ingredients/ingredientNameList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/ingredient/IngredientNameList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const ingredientNameList: Record<number, string | undefined> = {
 	// Fishes
 	1: 'merou_lujidane',

--- a/packages/core/src/models/items/boxOpening.ts
+++ b/packages/core/src/models/items/boxOpening.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/boxOpening.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-05-18.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ItemFiche } from './itemFiche.js';
 
 export interface BoxOpening {

--- a/packages/core/src/models/items/itemEffects.ts
+++ b/packages/core/src/models/items/itemEffects.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/ItemEffects.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { ItemEffect } from '../enums/ItemEffect.js';
 import { RaceEnum } from '../enums/Race.js';

--- a/packages/core/src/models/items/itemFeedback.ts
+++ b/packages/core/src/models/items/itemFeedback.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/feedBack.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozFiche } from '../dinoz/dinozFiche.js';
 import { ItemEffect } from '../enums/ItemEffect.js';
 

--- a/packages/core/src/models/items/itemFiche.ts
+++ b/packages/core/src/models/items/itemFiche.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/ItemFiche.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ItemType } from '../enums/ItemType.js';
 import type { PassiveEffects } from '../skills/skillDetails.js';
 import { SkillFightCondition } from '../skills/skillFightCondition.js';

--- a/packages/core/src/models/items/itemList.ts
+++ b/packages/core/src/models/items/itemList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/ItemList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-03-22.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { ItemEffect } from '../enums/ItemEffect.js';
 import { ItemType } from '../enums/ItemType.js';

--- a/packages/core/src/models/items/itemNameList.ts
+++ b/packages/core/src/models/items/itemNameList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/ItemNameList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-03-22.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const itemNameList: Record<number, string> = {
 	// when the corresponding asset exists, the item has been marked with an x in comment
 	1: 'potion_irma', // x

--- a/packages/core/src/models/items/itemProbability.ts
+++ b/packages/core/src/models/items/itemProbability.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/item/itemProbability.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-15.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { BoxOpening, BoxType } from './boxOpening.js';
 import { Item, itemList } from './itemList.js';
 

--- a/packages/core/src/models/messaging/threadBasic.ts
+++ b/packages/core/src/models/messaging/threadBasic.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/messagerie/threadsBasic.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-04-17.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export type MessagingUser = {
 	id: string;
 	name: string;

--- a/packages/core/src/models/monster/bossList.ts
+++ b/packages/core/src/models/monster/bossList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/BossList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { MapZone } from '../enums/MapZone.js';
 import { EntranceEffect } from '../fight/transpiler.js';
 import { Skill } from '../skills/skillList.js';

--- a/packages/core/src/models/monster/monsterFiche.ts
+++ b/packages/core/src/models/monster/monsterFiche.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/MonsterFiche.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-05-23.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Condition } from '../conditions/conditions.js';
 import { MapZone } from '../enums/MapZone.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';

--- a/packages/core/src/models/monster/monsterList.ts
+++ b/packages/core/src/models/monster/monsterList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/fight/MonsterList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-08-04.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { MapZone } from '../enums/MapZone.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';
 import { GameEvent } from '../events/events.js';

--- a/packages/core/src/models/place/place.ts
+++ b/packages/core/src/models/place/place.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/place/Place.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { placeListv2 } from './placeListv2.js';
 
 export type Place = (typeof placeListv2)[keyof typeof placeListv2] & {

--- a/packages/core/src/models/place/placeDisplayed.ts
+++ b/packages/core/src/models/place/placeDisplayed.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/place/PlaceDisplayed.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { MapZone } from '../enums/MapZone.js';
 import { PlaceIcon } from '../enums/PlaceIcon.js';
 

--- a/packages/core/src/models/place/placeListv2.ts
+++ b/packages/core/src/models/place/placeListv2.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/place/PlaceList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-04-01 through 2026-07-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { GatherType } from '../enums/GatherType.js';
 import { GroundEnum } from '../enums/GroundEnum.js';
 import { MapZone } from '../enums/MapZone.js';

--- a/packages/core/src/models/place/svgLines.ts
+++ b/packages/core/src/models/place/svgLines.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/place/svgLines.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export interface svgLines {
 	x1: number;
 	y1: number;

--- a/packages/core/src/models/rewards/epicReward.ts
+++ b/packages/core/src/models/rewards/epicReward.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/reward/EpicReward.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export interface EpicReward {
 	id: number;
 	name: string;

--- a/packages/core/src/models/rewards/rewardList.ts
+++ b/packages/core/src/models/rewards/rewardList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/reward/RewardList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-03-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { EpicReward } from './epicReward.js';
 
 export enum Reward {

--- a/packages/core/src/models/rewards/rewarder.ts
+++ b/packages/core/src/models/rewards/rewarder.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/reward/Rewarder.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { RewardEnum } from '../enums/Parser.js';
 import { ServiceEnum } from '../enums/Services.js';

--- a/packages/core/src/models/shop/shopFiche.ts
+++ b/packages/core/src/models/shop/shopFiche.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/shop/ShopFiche.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-28 through 2026-07-31.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Condition } from '../conditions/conditions.js';
 import { ItemType } from '../enums/ItemType.js';
 import { ShopType } from '../enums/ShopType.js';

--- a/packages/core/src/models/shop/shopListV2.ts
+++ b/packages/core/src/models/shop/shopListV2.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/shop/ShopList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-28 through 2026-04-01.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { PlaceEnum } from '../enums/PlaceEnum.js';
 import { ShopType } from '../enums/ShopType.js';

--- a/packages/core/src/models/skills/dinozSkillOwnAndUnlockable.ts
+++ b/packages/core/src/models/skills/dinozSkillOwnAndUnlockable.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/DinozSkillOwnAndUnlockable.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-17.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { SkillType } from '../enums/SkillType.js';
 

--- a/packages/core/src/models/skills/getAssaultStats.ts
+++ b/packages/core/src/models/skills/getAssaultStats.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/getAssaultStat.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozFiche } from '../dinoz/dinozFiche.js';
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { ElementType } from '../enums/ElementType.js';

--- a/packages/core/src/models/skills/getDefenseStats.ts
+++ b/packages/core/src/models/skills/getDefenseStats.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/getDefenseStat.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozFiche } from '../dinoz/dinozFiche.js';
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { ElementType } from '../enums/ElementType.js';

--- a/packages/core/src/models/skills/getSpecialStats.ts
+++ b/packages/core/src/models/skills/getSpecialStats.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/getSpecialStat.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DinozFiche } from '../dinoz/dinozFiche.js';
 import { DinozStatusId } from '../dinoz/statusList.js';
 import { ElementType } from '../enums/ElementType.js';

--- a/packages/core/src/models/skills/skillDetails.ts
+++ b/packages/core/src/models/skills/skillDetails.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/SkillDetails.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-01-20 through 2026-04-24.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { Energy } from '../enums/Energy.js';
 import { MathOperator } from '../enums/Parser.js';

--- a/packages/core/src/models/skills/skillFightCondition.ts
+++ b/packages/core/src/models/skills/skillFightCondition.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/SkillFightCondition.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Operator } from '../enums/Parser.js';
 import { FighterType } from '../fight/fighterType.js';
 import { FightStatus } from '../fight/fightStatus.js';

--- a/packages/core/src/models/skills/skillLevel.ts
+++ b/packages/core/src/models/skills/skillLevel.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/SkillLevel.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { Skill, skillList } from './skillList.js';
 
 const getSkillLevel = (skill: Skill) => {

--- a/packages/core/src/models/skills/skillList.ts
+++ b/packages/core/src/models/skills/skillList.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/dinoz/SkillList.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-29.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ElementType } from '../enums/ElementType.js';
 import { Energy } from '../enums/Energy.js';
 import { MathOperator, Operator } from '../enums/Parser.js';

--- a/packages/core/src/models/store/clanStore.ts
+++ b/packages/core/src/models/store/clanStore.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/store/StoreClan.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-06-13 through 2026-06-13.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { ClanLite } from '../clan/clan.js';
 
 export interface ClanStore {

--- a/packages/core/src/models/utils/entitySearch.ts
+++ b/packages/core/src/models/utils/entitySearch.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/models/rankings/EntitySearch.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2025-12-02.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export interface EntitySearch {
 	name: string;
 	id: number;

--- a/packages/core/src/models/utils/operatorProcess.ts
+++ b/packages/core/src/models/utils/operatorProcess.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/helper.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-02-09.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { MathOperator } from '../enums/Parser.js';
 import { EffectDescriptor } from '../skills/skillDetails.js';
 

--- a/packages/core/src/utils/dinozUtils.ts
+++ b/packages/core/src/utils/dinozUtils.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/DinozUtils.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-21.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { DINOZ_STATE, DinozState } from '../models/dinoz/dinozState.js';
 import { DinozForMaxXp } from '../models/dinoz/dinozXP.js';
 import { raceList } from '../models/dinoz/raceList.js';

--- a/packages/core/src/utils/fightConstants.ts
+++ b/packages/core/src/utils/fightConstants.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/fightConstants.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors from 2026-02-09 through 2026-07-30.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 export const TIME_BASE = 10;
 export const TIME_FACTOR = 10;
 // Start forced overtime before reaching the safety limit.

--- a/packages/core/src/utils/goals.ts
+++ b/packages/core/src/utils/goals.ts
@@ -1,3 +1,16 @@
+/**
+ * This file contains code derived from or adapted from:
+ * Eternaltwin DinoRPG
+ * Upstream file: https://gitlab.com/eternaltwin/dinorpg/dinorpg/-/blob/3a73bbc6d751e4916cc5fd2e5f23bc2cfd42fc6d/core/src/utils/twinoidGoals.mts
+ *
+ * Copyright in the original contributions remains with the respective
+ * authors and contributors.
+ *
+ * Modified by DinoRPG Remastered contributors on 2026-01-20.
+ * See NOTICE.md and the Git history for provenance and modification details.
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 import { StatTracking } from '../models/enums/StatsTracking.js';
 import { goals } from '../models/goals/goals.js';
 import { Goal, Unlock } from '../models/goals/goalsType.js';


### PR DESCRIPTION
## Summary

- Add per-file provenance notices for code derived from or adapted from
  Eternaltwin DinoRPG.
- Identify the immutable upstream source file and revision.
- Document modification periods and the applicable AGPL-3.0-or-later license.
- Expand NOTICE.md with Eternaltwin, Motion Twin, and Ruffle attribution.
- Add provenance information to the tracked Prisma schema.
- Preserve Ruffle's MIT and Apache-2.0 license files unchanged.
- Exclude independently created, generated, generic, and unrelated files
  from Eternaltwin attribution.

## Validation

- Manual provenance review completed.
- Lint and build pass.
- No generated Prisma Client or Ruffle bundle received an Eternaltwin notice.