### PR TITLE
Feat: Account reset & deletion overhaul

### DIFF
--- a/app/client/src/components/account/ProfileGame.vue
+++ b/app/client/src/components/account/ProfileGame.vue
@@ -92,29 +92,19 @@
 				{{ $t(`accountPage.options.title`) }}
 				<img :src="getImgURL('icons', 'info_button')" alt="info_button" />
 			</h3>
-			<dl>
-				<DZButton @click="openPasswordModal">{{ $t(`accountPage.options.mdp`) }}</DZButton>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-			</dl>
 			<div class="buttonLand" v-if="isMyAccount()">
-				<!--<DZButton href="" @click="resetAccount()">{{ $t(`myAccount.options.reset`) }}</DZButton>-->
-				<DZButton class="bSmall" back @click="option = false">{{ $t(`accountPage.options.retour`) }}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openPasswordModal">{{
+					$t(`accountPage.options.mdp`)
+				}}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openResetModal">{{
+					$t(`accountPage.options.reset`)
+				}}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openDeleteModal">{{
+					$t(`accountPage.options.delete`)
+				}}</DZButton>
+				<DZButton class="bSmall no-first-letter" back @click="option = false">{{
+					$t(`accountPage.options.retour`)
+				}}</DZButton>
 			</div>
 		</div>
 	</transition>
@@ -125,6 +115,16 @@
 		:with-old-password="true"
 		@close="closePasswordModal"
 		@submit="submitPasswordChange"
+	/>
+	<ConfirmActionModal
+		v-if="confirmActionModalOpen"
+		:title="confirmActionConfig.title"
+		:description="confirmActionConfig.description"
+		:actionType="confirmActionConfig.actionType"
+		:loading="confirmActionLoading"
+		:error="confirmActionError"
+		@close="closeConfirmActionModal"
+		@submit="submitConfirmAction"
 	/>
 </template>
 
@@ -159,13 +159,22 @@ export default defineComponent({
 			//dinozStore: dinozStore()
 			passwordModalOpen: false,
 			passwordLoading: false,
-			passwordError: null as string | null
+			passwordError: null as string | null,
+			confirmActionModalOpen: false,
+			confirmActionLoading: false,
+			confirmActionError: null as string | null,
+			confirmActionConfig: {
+				title: '',
+				description: '',
+				actionType: 'delete' as 'delete' | 'reset'
+			}
 		};
 	},
 	components: {
 		DZUser: defineAsyncComponent(() => import('../utils/DZUser.vue')),
 		DZButton,
-		ChangePasswordModal
+		ChangePasswordModal,
+		ConfirmActionModal: defineAsyncComponent(() => import('../modal/ConfirmActionModal.vue'))
 	},
 	props: {
 		profile: {
@@ -223,6 +232,59 @@ export default defineComponent({
 				errorHandler.handle(err, this.$toast);
 			} finally {
 				this.passwordLoading = false;
+			}
+		},
+		openResetModal() {
+			this.confirmActionConfig = {
+				title: this.$t('accountPage.options.resetTitle'),
+				description: this.$t('accountPage.options.resetDescription'),
+				actionType: 'reset'
+			};
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = true;
+		},
+		openDeleteModal() {
+			this.confirmActionConfig = {
+				title: this.$t('accountPage.options.deleteTitle'),
+				description: this.$t('accountPage.options.deleteDescription'),
+				actionType: 'delete'
+			};
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = true;
+		},
+		closeConfirmActionModal() {
+			if (this.confirmActionLoading) return;
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = false;
+		},
+		async submitConfirmAction(payload: { password: string }) {
+			this.confirmActionError = null;
+			this.confirmActionLoading = true;
+			try {
+				if (this.confirmActionConfig.actionType === 'delete') {
+					await UserService.deleteAccount(payload.password);
+				} else {
+					await UserService.resetAccount(payload.password);
+				}
+				this.confirmActionModalOpen = false;
+
+				// Clear the user store to trigger a logout state
+				this.uStore.clearUser();
+				// Redirect to home
+				window.location.href = '/';
+			} catch (err: any) {
+				const errMsg = err?.response?.data?.message || err?.message;
+				if (errMsg === 'userInClan') {
+					this.confirmActionError =
+						"Vous ne pouvez pas faire ça car vous êtes dans un clan. Veuillez d'abord le quitter.";
+				} else if (errMsg === 'invalidConfirmation') {
+					this.confirmActionError = 'Mot de passe incorrect.';
+				} else {
+					errorHandler.handle(err, this.$toast);
+					this.confirmActionError = 'Une erreur est survenue.';
+				}
+			} finally {
+				this.confirmActionLoading = false;
 			}
 		},
 		startProfileTextEdit() {
@@ -407,8 +469,22 @@ export default defineComponent({
 	margin-bottom: auto;
 	align-items: center;
 	margin-bottom: 5px;
-	* {
+	> * {
 		margin-bottom: 5px;
+	}
+}
+.btn-wide {
+	width: auto !important;
+	min-width: 145px;
+	padding: 0 15px;
+	background-size: 100% 100% !important;
+}
+.no-first-letter {
+	&::first-letter {
+		color: inherit !important;
+	}
+	:deep(span::first-letter) {
+		color: inherit !important;
 	}
 }
 .tinybutton {

--- a/app/client/src/components/bank/BankSavings.vue
+++ b/app/client/src/components/bank/BankSavings.vue
@@ -21,6 +21,16 @@
 					:disabled="saving || maxSavingAmount <= 0"
 					@input="normalizeAmount"
 				/>
+				<p
+					class="maxDeposit"
+					v-html="
+						formatContent(
+							$t('bank.savings.maxDeposit', {
+								gold: beautifulNumber(BANK_SAVING_MAX_DEPOSIT)
+							})
+						)
+					"
+				/>
 				<label for="bankSavingDuration">{{ $t('bank.savings.duration') }}</label>
 				<DZSelect
 					id="bankSavingDuration"
@@ -101,7 +111,8 @@ export default defineComponent({
 	setup() {
 		const uStore = userStore();
 		return {
-			uStore
+			uStore,
+			BANK_SAVING_MAX_DEPOSIT
 		};
 	},
 	data() {
@@ -198,8 +209,8 @@ export default defineComponent({
 				this.amount = 1;
 				return;
 			}
-			if (amount > this.uStore.gold) {
-				this.amount = this.uStore.gold;
+			if (amount > this.maxSavingAmount) {
+				this.amount = this.maxSavingAmount;
 				return;
 			}
 			this.amount = amount;
@@ -327,6 +338,12 @@ export default defineComponent({
 		display: flex;
 		flex-direction: column;
 		gap: 3px;
+	}
+	.maxDeposit {
+		margin: 0;
+		text-align: center;
+		font-size: 9pt;
+		opacity: 0.85;
 	}
 }
 @media (max-width: 540px) {

--- a/app/client/src/components/common/LeftPanel.vue
+++ b/app/client/src/components/common/LeftPanel.vue
@@ -14,10 +14,8 @@
 <template>
 	<div id="accountList">
 		<div class="money">
-			<span class="moneyValue">
-				{{ beautifulNumber(displayedAmount) }}
-			</span>
-			<img :src="walletIcon" :alt="selectedWallet" />
+			<span class="moneyValue">{{ beautifulNumber(displayedAmount) }}</span>
+			<img class="wallet-icon" :src="walletIcon" :alt="selectedWallet" />
 		</div>
 		<DZSelect id="wallet-select" class="moneySelect" v-model="selectedWallet" :options="walletOptions" />
 		<div class="iconMenu">
@@ -294,6 +292,7 @@ export default defineComponent({
 		font-weight: bold;
 		img {
 			vertical-align: -5%;
+			margin-left: 4px;
 		}
 	}
 	.moneySelect {

--- a/app/client/src/components/market/OfferLine.vue
+++ b/app/client/src/components/market/OfferLine.vue
@@ -61,11 +61,9 @@
 			<p v-if="bestBid">
 				<span>{{ $t('market.highestBid') }}:</span>
 				<span>
-					<span class="bid-value">{{ bestBid.value }}</span>
-					<img :src="getImgURL('icons', 'ticket')" />
-					<span>{{ $t('market.by') }} </span>
-					<DZUser v-if="bestBid.user" :user="bestBid.user" />
-					<span v-else>{{ bestBid.userName }}</span>
+					<span class="bid-value">{{ bestBid.value }}</span
+					><img :src="getImgURL('icons', 'ticket')" /><span>{{ $t('market.by') }}</span
+					>&nbsp;<DZUser v-if="bestBid.user" :user="bestBid.user" /><span v-else>{{ bestBid.userName }}</span>
 				</span>
 			</p>
 			<p v-else>

--- a/app/client/src/components/modal/ConfirmActionModal.vue
+++ b/app/client/src/components/modal/ConfirmActionModal.vue
@@ -1,0 +1,152 @@
+<template>
+	<div class="modal-background">
+		<div class="password-modal">
+			<h3>{{ title }}</h3>
+			<p class="description">{{ description }}</p>
+
+			<div class="field">
+				<label for="passwordInput">{{ labelText }}</label>
+				<DZInput
+					id="passwordInput"
+					v-model="form.password"
+					type="password"
+					:placeholder="$t('modal.confirmAction.passwordPlaceholder')"
+					autocomplete="off"
+				/>
+			</div>
+
+			<p v-if="localError" class="password-error">{{ localError }}</p>
+			<p v-else-if="error" class="password-error">{{ error }}</p>
+
+			<div class="buttonLand">
+				<DZButton class="bSmall no-first-letter" @click="submit">
+					{{ loading ? $t('modal.confirmAction.loading') : $t('modal.confirmAction.confirm') }}
+				</DZButton>
+				<DZButton class="bSmall no-first-letter" back @click="$emit('close')">{{
+					$t('modal.confirmAction.cancel')
+				}}</DZButton>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import DZInput from '../utils/DZInput.vue';
+import DZButton from '../utils/DZButton.vue';
+
+const { t } = useI18n();
+
+const props = withDefaults(
+	defineProps<{
+		title: string;
+		description: string;
+		label?: string;
+		loading?: boolean;
+		error?: string | null;
+		actionType?: 'reset' | 'delete';
+	}>(),
+	{
+		label: '',
+		loading: false,
+		error: null,
+		actionType: 'delete'
+	}
+);
+
+const labelText = computed(() => props.label || t('modal.confirmAction.label'));
+
+const emit = defineEmits<{
+	close: [];
+	submit: [
+		payload: {
+			password: string;
+		}
+	];
+}>();
+
+const localError = ref<string | null>(null);
+
+const form = reactive({
+	password: ''
+});
+
+function submit() {
+	localError.value = null;
+
+	if (!form.password) {
+		localError.value = t('modal.confirmAction.passwordRequired');
+		return;
+	}
+
+	emit('submit', { password: form.password });
+}
+</script>
+
+<style scoped lang="scss">
+@use 'sass:color';
+.modal-background {
+	position: absolute;
+	background: color.adjust(#09092d, $alpha: -0.4);
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 999;
+	transition: all 0.3s;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+}
+.password-modal {
+	width: min(420px, calc(100% - 32px));
+	background-color: #ecbd84;
+	border: 2px solid #bc683c;
+	padding: 20px;
+	color: #7b3f22;
+	h3 {
+		margin-top: 0;
+		color: #9a4029;
+	}
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 12px;
+	}
+	:deep(input) {
+		border: none;
+		background-color: #ae6139;
+		color: #ffee92;
+		padding: 6px;
+	}
+	:deep(input:focus) {
+		background-color: #9a4029;
+		outline: none;
+	}
+}
+.description {
+	margin-bottom: 20px;
+	font-size: 14px;
+	color: #7b3f22;
+}
+.password-error {
+	color: #8f1d12;
+	font-weight: bold;
+}
+.buttonLand {
+	display: flex;
+	justify-content: space-around;
+	margin-top: 15px;
+}
+.no-first-letter {
+	&::first-letter {
+		color: inherit !important;
+	}
+	:deep(span::first-letter) {
+		color: inherit !important;
+	}
+}
+</style>

--- a/app/client/src/i18n/locales/FR.json
+++ b/app/client/src/i18n/locales/FR.json
@@ -751,7 +751,8 @@
 		"concentrationFull": "Les sept places de cette concentration sont déjà occupées.",
 		"concentrationCannotStopAfterOpening": "La concentration est terminée : le Dinoz doit maintenant entrer dans le portail.",
 		"concentrationNotCompleted": "Sept Dinoz doivent terminer leur concentration avant que le portail puisse être franchi.",
-		"maxFollowers": "Vous ne pouvez avoir plus de {maxFollowers} Dinoz dans votre groupe."
+		"maxFollowers": "Vous ne pouvez avoir plus de {maxFollowers} Dinoz dans votre groupe.",
+		"keepSeedReincarnationLimitReached": "Vous avez atteint la limite de {limit} réincarnations conservant la même destinée."
 	},
 	"tooltip": {
 		"gold": "L'or permet d'acheter de nouveaux **Dinoz** ou des **objets** en boutique.",

--- a/app/client/src/i18n/locales/FR.json
+++ b/app/client/src/i18n/locales/FR.json
@@ -3789,7 +3789,8 @@
 			"itemDuration": "Durée : {days} jours",
 			"itemGain": "Gain : **{gold}** :gold: — Total : **{total}** :gold:",
 			"unlockAt": "Disponible le {date}",
-			"claim": "Récupérer"
+			"claim": "Récupérer",
+			"maxDeposit": "Dépôt maximum : {gold} :gold:"
 		}
 	},
 	"npc": {

--- a/app/client/src/i18n/locales/FR.json
+++ b/app/client/src/i18n/locales/FR.json
@@ -581,6 +581,14 @@
 				"passwordMismatch": "Les nouveaux mots de passe ne correspondent pas."
 			}
 		},
+		"confirmAction": {
+			"label": "Veuillez entrer votre mot de passe pour confirmer :",
+			"passwordPlaceholder": "Mot de passe",
+			"loading": "Chargement...",
+			"confirm": "Confirmer",
+			"cancel": "Annuler",
+			"passwordRequired": "Veuillez entrer votre mot de passe pour confirmer."
+		},
 		"modif": "Modification...",
 		"valid": "Valider",
 		"close": "Fermer",
@@ -681,7 +689,7 @@
 		"Missing_device_cookie": "Impossible d’identifier votre navigateur. Veuillez autoriser les cookies et réessayer.",
 		"Too_many_accounts_created_from_this_device_this_month": "Trop de comptes ont été créés depuis ce navigateur ce mois-ci. Veuillez réessayer le mois prochain.",
 		"Too_many_accounts_created_from_this_network_this_month": "Trop de comptes ont été créés depuis ce réseau ce mois-ci. Veuillez réessayer le mois prochain.",
-		"userNotFound": "Le joueur {userId} n'a pas été trouvé.",
+		"userNotFound": "Le joueur {userId} a été supprimé ou n'existe plus.",
 		"dinozNotFound": "Le Dinoz {dinozId} n'a pas été trouvé.",
 		"dinozDoesNotBelongToUser": "Le Dinoz {dinozId} n'appartient pas au joueur {userId}.",
 		"invalidId": "L'id est invalide",
@@ -813,6 +821,17 @@
 		"userTitle": "Joueur : {name}",
 		"noDescription": "Aucune description sur ce profil...",
 		"editProfile": "Editer mon profil",
+		"options": {
+			"title": "Options du compte",
+			"mdp": "Modifier le MDP",
+			"reset": "Recommencer le compte",
+			"delete": "Supprimer le compte",
+			"resetTitle": "Recommencer le compte",
+			"resetDescription": "Êtes-vous sûr de vouloir tout recommencer ? Vous conserverez votre nom, votre description, votre avatar et votre messagerie. Cependant, TOUS VOS DINOZ, VOTRE INVENTAIRE ET VOTRE ARGENT SERONT DÉFINITIVEMENT PERDUS. Vous recommencerez l'aventure à zéro avec 100 000 pièces d'or.",
+			"deleteTitle": "Supprimer le compte",
+			"deleteDescription": "ATTENTION : Êtes-vous absolument sûr de vouloir supprimer votre compte ? Cette action effacera DÉFINITIVEMENT votre progression, vos dinoz, votre inventaire et votre profil. CETTE ACTION EST IRRÉVERSIBLE.",
+			"retour": "Retour"
+		},
 		"changeAvatar": "Changer l'avatar",
 		"save": "Sauvegarder le profil",
 		"cancel": "Annuler les changements",
@@ -830,13 +849,6 @@
 		"editAccount": "Modifier le profil",
 		"edit": "Editer",
 		"descriptionUpdated": "Description mise à jour !",
-		"options": {
-			"title": "Options du compte",
-			"mdp": "Modifier le MDP",
-			"todo": "à venir...",
-			"reset": "Réinitialiser le compte",
-			"retour": "Retour"
-		},
 		"goals": {
 			"title": "Statistiques DinoRPG",
 			"points": "points",
@@ -6370,7 +6382,6 @@
 				},
 				"end": "Sahalami ne terrorisera plus personne. Reste à élucider le mystère de ce pendentif..."
 			},
-
 			"penden": {
 				"name": "Un collier bien mystérieux",
 				"begin": "Le pendentif en forme de Couperet de cuisine trouvé sur Sahalami est quand même très étrange... Vous devriez mener l'enquête à son sujet.",
@@ -6386,7 +6397,6 @@
 				},
 				"end": "Vous avez obtenu les informations qu'il vous fallait. "
 			},
-
 			"hunt1": {
 				"name": "On recherche: Tripou le mou",
 				"begin": "« ON RECHERCHE : Tripou, le pillard mou des nuits sans lune. Les derniers rapports font état d'une attaque au pied de la Dévoreuse du nord. Mission très dangereuse, belle récompense à prévoir. »",
@@ -6442,7 +6452,6 @@
 				},
 				"end": "Vous avez réussi à vaincre Tripou ! Félicitations !"
 			},
-
 			"hunt2": {
 				"name": "On recherche: Boukané l'intuable",
 				"begin": "« ON RECHERCHE : Boukané, l'intuable tortionnaire des abîmes insondables ! Il se terre dans son repaire en Extrême Occident, mission hautement périlleuse ! »",
@@ -6475,7 +6484,6 @@
 				},
 				"end": "Vous avez déjoué les plans de Boukané. De toutes évidences, il s'apprêtait à attaquer la Citadelle par son point faible..."
 			},
-
 			"hunt3": {
 				"name": "On recherche: Cervelah l'empoisonneur",
 				"begin": "« ON RECHERCHE : Cervelah, l'empoisonneur verdâtre. Grand, brun, porte une capuche et est toujours accompagné de Pikouz, son fidèle scorpwink. Individu extrêmement hostile. Forte prime offerte par le Consortium des Filous Associés ! Contactez Aboul Tonhor, marchand aux Pylônes. »",

--- a/app/client/src/i18n/locales/FR.json
+++ b/app/client/src/i18n/locales/FR.json
@@ -674,7 +674,6 @@
 			"amnesic_rice": "Votre Dinoz ne sait plus comment il se prénomme, il a également perdu toute son expérience :xp: !",
 			"pampleboum": "Ouille ! Il y avait un noyau dans ce pampleboum !"
 		},
-		"Invalid_email_or_password": "Pseudo ou mot de passe invalide.",
 		"Invalid_credentials": "Identifiants incorrects.",
 		"Too_many_login_attempts": "Trop de tentatives de connexion ont été effectuées. Par sécurité, veuillez patienter 5 minutes avant de réessayer.",
 		"Too_many_registration_attempts": "Trop de tentatives de création de compte ont été effectuées. Veuillez patienter 1 heure avant de réessayer.",

--- a/app/client/src/services/user.service.ts
+++ b/app/client/src/services/user.service.ts
@@ -72,5 +72,15 @@ export const UserService = {
 		return api.post<GameRulesAcceptance>('/users/me/rules/accept', {
 			version
 		});
+	},
+	deleteAccount(password: string): Promise<void> {
+		return api.delete<void>('/users/me/delete', {
+			data: { password }
+		});
+	},
+	resetAccount(password: string): Promise<void> {
+		return api.post<void>('/users/me/reset', {
+			password
+		});
 	}
 };

--- a/app/server/prisma/migrations/20260819182214_add_keep_seed_reincarnation_count/migration.sql
+++ b/app/server/prisma/migrations/20260819182214_add_keep_seed_reincarnation_count/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "keepSeedReincarnationCount" INTEGER NOT NULL DEFAULT 0;

--- a/app/server/prisma/schema.prisma
+++ b/app/server/prisma/schema.prisma
@@ -607,6 +607,8 @@ model User {
   matelasseur   Boolean            @default(false)
   messie        Boolean            @default(false)
 
+  keepSeedReincarnationCount Int   @default(0)
+
   newsLikes     NewsLike[]
   pollVotes     PollVote[]
 

--- a/app/server/src/Dialog/Controller/dialog.effects.ts
+++ b/app/server/src/Dialog/Controller/dialog.effects.ts
@@ -7,6 +7,7 @@ import { ItemType } from '@dinorpg/core/models/enums/ItemType.js';
 import { Item, itemList } from '@dinorpg/core/models/items/itemList.js';
 import { rewardIdByKey, statTrackingByCollectionKey } from '@dinorpg/core/models/rewards/rewardsKeyMap.js';
 import {
+	MERGUEZ_CARD_MAX_QUANTITY,
 	MERGUEZ_CARD_REWARD_KEY,
 	MERGUEZ_DEFAULT_MAX_QUANTITY,
 	MERGUEZ_SHOPKEEPER_MAX_QUANTITY,
@@ -79,11 +80,12 @@ function getDialogItemMaxQuantity(context: DialogContext, itemId: number) {
 	if (!item) {
 		throw new ExpectedError(`Item ${itemId} does not exist`);
 	}
-
 	if (item.itemId === Item.GOBLIN_MERGUEZ) {
 		const userHasMerguezCard = context.user.collections.has(MERGUEZ_CARD_REWARD_KEY);
-		if (context.user.shopKeeper && userHasMerguezCard) {
-			return MERGUEZ_SHOPKEEPER_MAX_QUANTITY; // 150
+		if (userHasMerguezCard) {
+			return context.user.shopKeeper
+				? MERGUEZ_SHOPKEEPER_MAX_QUANTITY // 150
+				: MERGUEZ_CARD_MAX_QUANTITY; // 100
 		}
 		if (context.user.shopKeeper) {
 			return SHOPKEEPER_MAX_QUANTITY; // 30

--- a/app/server/src/Dinoz/Service/reincarnateDinoz.service.ts
+++ b/app/server/src/Dinoz/Service/reincarnateDinoz.service.ts
@@ -4,7 +4,10 @@ import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
 import { getRace } from '@dinorpg/core/utils/dinozUtils.js';
 import { FastifyReply, FastifyRequest } from 'fastify';
 
+import { Role } from '../../../../prisma/client.js';
+import gameConfig from '../../config/game.config.js';
 import { computeUSkillsForUser } from '../../Level/Controller/applySkillEffect.controller.js';
+import { prisma } from '../../prisma.js';
 import { updatePoints } from '../../Ranking/Controller/updatePoints.js';
 import { removeMoney } from '../../User/Controller/money.controller.js';
 import { reincarnateDinoz } from '../../utils/dinoz/level.mapper.js';
@@ -49,6 +52,39 @@ export async function reincarnate(
 		throw new ExpectedError('reincarnationWithEquippedItems', { params: { id: dinozId } });
 	}
 	const race = getRace(dinoz.raceId);
+	const user = await prisma.user.findUnique({
+		where: {
+			id: authed.id
+		},
+		select: {
+			role: true
+		}
+	});
+	if (!user) {
+		throw new ExpectedError('userNotFound');
+	}
+	if (keepSeed && user.role !== Role.ADMIN) {
+		const quota = await prisma.user.updateMany({
+			where: {
+				id: authed.id,
+				keepSeedReincarnationCount: {
+					lt: gameConfig.dinoz.maxKeepSeedReincarnations
+				}
+			},
+			data: {
+				keepSeedReincarnationCount: {
+					increment: 1
+				}
+			}
+		});
+		if (quota.count === 0) {
+			throw new ExpectedError('keepSeedReincarnationLimitReached', {
+				params: {
+					limit: gameConfig.dinoz.maxKeepSeedReincarnations
+				}
+			});
+		}
+	}
 	if (keepSeed) {
 		await removeMoney(authed.id, Math.round(race.price * dinoz.level ** 0.5));
 	}

--- a/app/server/src/Inventory/Service/getAllItemsData.service.ts
+++ b/app/server/src/Inventory/Service/getAllItemsData.service.ts
@@ -19,9 +19,11 @@ type ItemMaxQuantityUser = {
 };
 
 export const getItemMaxQuantity = (userInventory: ItemMaxQuantityUser, item: ItemFiche): number => {
-	const hasMerguezCard = userInventory.rewards.some(reward => reward.rewardId === Reward.MERGUEZ_CARD);
-	if (item.itemId === Item.GOBLIN_MERGUEZ && hasMerguezCard) {
-		return userInventory.shopKeeper ? MERGUEZ_SHOPKEEPER_MAX_QUANTITY : MERGUEZ_CARD_MAX_QUANTITY;
+	if (item.itemId === Item.GOBLIN_MERGUEZ) {
+		const hasMerguezCard = userInventory.rewards.some(reward => reward.rewardId === Reward.MERGUEZ_CARD);
+		if (hasMerguezCard) {
+			return userInventory.shopKeeper ? MERGUEZ_SHOPKEEPER_MAX_QUANTITY : MERGUEZ_CARD_MAX_QUANTITY;
+		}
 	}
 	if (userInventory.shopKeeper && item.itemType !== ItemType.MAGICAL) {
 		return Math.round(item.maxQuantity * 1.5);

--- a/app/server/src/Market/Helpers/cleanMarketForAccountDeletion.helper.ts
+++ b/app/server/src/Market/Helpers/cleanMarketForAccountDeletion.helper.ts
@@ -1,0 +1,48 @@
+import { MoneyType, Prisma } from '../../../../prisma/index.js';
+
+export async function cleanMarketForAccountDeletionTx(tx: Prisma.TransactionClient, userId: string) {
+	// 1. Gérer les offres dont l'utilisateur est le vendeur
+	const userOffers = await tx.offer.findMany({
+		where: {
+			sellerId: userId,
+			status: 'ONGOING'
+		},
+		include: {
+			bids: true
+		}
+	});
+
+	for (const offer of userOffers) {
+		// Rembourser les enchérisseurs (s'ils existent)
+		for (const bid of offer.bids) {
+			if (bid.userId) {
+				await tx.userWallet.updateMany({
+					where: {
+						userId: bid.userId,
+						type: MoneyType.TREASURE_TICKET
+					},
+					data: {
+						amount: { increment: bid.value }
+					}
+				});
+			}
+		}
+
+		// Supprimer l'offre (ce qui supprimera aussi les bids associés via onDelete: Cascade)
+		await tx.offer.delete({
+			where: { id: offer.id }
+		});
+	}
+
+	// 2. Gérer les enchères placées par l'utilisateur sur d'autres offres
+	// Le simple fait de supprimer ses enchères rend la main à l'enchérisseur précédent.
+	// Son argent investi est détruit (car son compte est supprimé/réinitialisé).
+	await tx.offerBid.deleteMany({
+		where: {
+			userId: userId,
+			offer: {
+				status: 'ONGOING'
+			}
+		}
+	});
+}

--- a/app/server/src/User/Controller/deleteUser.controller.ts
+++ b/app/server/src/User/Controller/deleteUser.controller.ts
@@ -1,0 +1,77 @@
+import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
+import bcrypt from 'bcrypt';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { ACCESS_TOKEN_COOKIE, authCookieBaseOptions } from '../../config/cookie.js';
+import { cleanMarketForAccountDeletionTx } from '../../Market/Helpers/cleanMarketForAccountDeletion.helper.js';
+import { prisma } from '../../prisma.js';
+
+export async function deleteUser(req: FastifyRequest<{ Body: { password: string } }>, reply: FastifyReply) {
+	const userId = req.user.id;
+	const password = req.body?.password;
+
+	if (!password) {
+		throw new ExpectedError('invalidConfirmation');
+	}
+
+	await prisma.$transaction(async tx => {
+		const user = await tx.user.findUnique({
+			where: { id: userId },
+			include: { ClanMember: true, leaderOf: true }
+		});
+
+		if (!user) {
+			throw new ExpectedError('userNotFound');
+		}
+
+		const isMatch = await bcrypt.compare(password, user.password);
+		if (!isMatch) {
+			throw new ExpectedError('invalidConfirmation');
+		}
+
+		if (user.ClanMember || user.leaderOf) {
+			throw new ExpectedError('userInClan');
+		}
+
+		// 1. Nettoyer le marché
+		await cleanMarketForAccountDeletionTx(tx, userId);
+
+		// 2. Nettoyage manuel des tables sans onDelete: Cascade
+		await tx.userWallet.deleteMany({ where: { userId } });
+		await tx.userProfile.deleteMany({ where: { userId } });
+		await tx.ranking.deleteMany({ where: { userId } });
+		await tx.devourerControl.deleteMany({ where: { userId } });
+		await tx.clanJoinRequest.deleteMany({ where: { userId } });
+
+		// 3. Anonymiser les traces du joueur (conversations, clan, marché)
+		await tx.message.updateMany({
+			where: { senderId: userId },
+			data: { senderNameSnapshot: 'inconnu' }
+		});
+		await tx.participant.updateMany({
+			where: { userId: userId },
+			data: { userNameSnapshot: 'inconnu' }
+		});
+		await tx.clanMessage.updateMany({
+			where: { authorId: userId },
+			data: { authorName: 'inconnu' }
+		});
+		await tx.offer.updateMany({
+			where: { sellerId: userId },
+			data: { sellerName: 'inconnu' }
+		});
+		await tx.offerBid.updateMany({
+			where: { userId: userId },
+			data: { userName: 'inconnu' }
+		});
+
+		// 4. Supprimer le User (ce qui supprimera le reste en cascade ou mettra SetNull selon les relations)
+		await tx.user.delete({
+			where: { id: userId }
+		});
+	});
+
+	// Déconnexion
+	reply.clearCookie(ACCESS_TOKEN_COOKIE, authCookieBaseOptions);
+	return reply.send({ ok: true });
+}

--- a/app/server/src/User/Controller/loginUser.controller.ts
+++ b/app/server/src/User/Controller/loginUser.controller.ts
@@ -6,6 +6,8 @@ import { ACCESS_TOKEN_COOKIE, authCookieOptions } from '../../config/cookie.js';
 import { prisma } from '../../prisma.js';
 import { LoginUserInput } from '../Schema/user.schema.js';
 
+const DUMMY_PASSWORD_HASH = '$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy';
+
 export async function loginUser(
 	req: FastifyRequest<{
 		Body: LoginUserInput;
@@ -14,12 +16,11 @@ export async function loginUser(
 ) {
 	const { name, password } = req.body;
 	const user = await prisma.user.findUnique({ where: { name: name } });
-	if (!user) {
-		throw new ExpectedError('Invalid_credentials', { statusCode: 401 });
-	}
-	const isMatch = user && (await bcrypt.compare(password, user.password));
+	const isMatch = await bcrypt.compare(password, user?.password ?? DUMMY_PASSWORD_HASH);
 	if (!user || !isMatch) {
-		throw new ExpectedError('Invalid_email_or_password', { statusCode: 401 });
+		throw new ExpectedError('Invalid_credentials', {
+			statusCode: 401
+		});
 	}
 	if (user.bannedUntil && user.bannedUntil > new Date()) {
 		throw new ExpectedError('Account_banned_until', {

--- a/app/server/src/User/Controller/money.controller.ts
+++ b/app/server/src/User/Controller/money.controller.ts
@@ -31,17 +31,22 @@ export async function addMoney(userId: string, money: number) {
 }
 
 export async function addTreasureTicket(userId: string, money: number) {
-	return prisma.userWallet.update({
+	return prisma.userWallet.upsert({
 		where: {
 			userId_type: {
 				userId,
 				type: MoneyType.TREASURE_TICKET
 			}
 		},
-		data: {
+		update: {
 			amount: {
 				increment: money
 			}
+		},
+		create: {
+			userId,
+			type: MoneyType.TREASURE_TICKET,
+			amount: money
 		}
 	});
 }

--- a/app/server/src/User/Controller/resetUser.controller.ts
+++ b/app/server/src/User/Controller/resetUser.controller.ts
@@ -49,12 +49,24 @@ export async function resetUser(req: FastifyRequest<{ Body: { password: string }
 		await tx.userDinozShop.deleteMany({ where: { userId } });
 		await tx.clanJoinRequest.deleteMany({ where: { userId } });
 		await tx.devourerControl.deleteMany({ where: { userId } });
+		await tx.bankSaving.deleteMany({ where: { userId } });
 
-		// 3. Réinitialiser les compteurs du User
+		// 3. Réinitialiser les compteurs et compétences uniques du User
 		await tx.user.update({
 			where: { id: userId },
 			data: {
-				devourerAttacksLeft: 3
+				devourerAttacksLeft: 3,
+				leader: false,
+				engineer: false,
+				cooker: false,
+				shopKeeper: false,
+				merchant: false,
+				priest: false,
+				teacher: false,
+				matelasseur: false,
+				messie: false,
+				discoveredSkills: [],
+				keepSeedReincarnationCount: 0
 			}
 		});
 		await tx.ranking.update({

--- a/app/server/src/User/Controller/resetUser.controller.ts
+++ b/app/server/src/User/Controller/resetUser.controller.ts
@@ -1,0 +1,92 @@
+import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
+import bcrypt from 'bcrypt';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { ACCESS_TOKEN_COOKIE, authCookieBaseOptions } from '../../config/cookie.js';
+import gameConfig from '../../config/game.config.js';
+import { cleanMarketForAccountDeletionTx } from '../../Market/Helpers/cleanMarketForAccountDeletion.helper.js';
+import { prisma } from '../../prisma.js';
+
+export async function resetUser(req: FastifyRequest<{ Body: { password: string } }>, reply: FastifyReply) {
+	const userId = req.user.id;
+	const password = req.body?.password;
+
+	if (!password) {
+		throw new ExpectedError('invalidConfirmation');
+	}
+
+	await prisma.$transaction(async tx => {
+		const user = await tx.user.findUnique({
+			where: { id: userId },
+			include: { ClanMember: true, leaderOf: true }
+		});
+
+		if (!user) {
+			throw new ExpectedError('userNotFound');
+		}
+
+		const isMatch = await bcrypt.compare(password, user.password);
+		if (!isMatch) {
+			throw new ExpectedError('invalidConfirmation');
+		}
+
+		if (user.ClanMember || user.leaderOf) {
+			throw new ExpectedError('userInClan');
+		}
+
+		// 1. Nettoyer le marché
+		await cleanMarketForAccountDeletionTx(tx, userId);
+
+		// 2. Supprimer manuellement l'inventaire complet, les dinoz, la boutique, etc.
+		// Attention : L'ordre est important si certaines contraintes existent.
+		await tx.dinoz.deleteMany({ where: { userId } });
+		await tx.userItems.deleteMany({ where: { userId } });
+		await tx.userIngredients.deleteMany({ where: { userId } });
+		await tx.userGather.deleteMany({ where: { userId } });
+		await tx.userRewards.deleteMany({ where: { userId } });
+		await tx.userScenario.deleteMany({ where: { userId } });
+		await tx.userTracking.deleteMany({ where: { userId } });
+		await tx.userDinozShop.deleteMany({ where: { userId } });
+		await tx.clanJoinRequest.deleteMany({ where: { userId } });
+		await tx.devourerControl.deleteMany({ where: { userId } });
+
+		// 3. Réinitialiser les compteurs du User
+		await tx.user.update({
+			where: { id: userId },
+			data: {
+				devourerAttacksLeft: 3
+			}
+		});
+		await tx.ranking.update({
+			where: { userId },
+			data: {
+				dinozCount: 0,
+				points: 0,
+				average: 0,
+				completion: 0,
+				dojo: 0
+			}
+		});
+
+		// 4. Réinitialiser les portefeuilles (seulement de l'or pour le reset)
+		await tx.userWallet.deleteMany({ where: { userId } });
+		await tx.userWallet.createMany({
+			data: [
+				{
+					userId,
+					type: 'GOLD',
+					amount: 100000
+				},
+				{
+					userId,
+					type: 'TREASURE_TICKET',
+					amount: 0
+				}
+			]
+		});
+	});
+
+	// Déconnexion
+	reply.clearCookie(ACCESS_TOKEN_COOKIE, authCookieBaseOptions);
+	return reply.send({ ok: true });
+}

--- a/app/server/src/User/Controller/toolTipInfosUser.controller.ts
+++ b/app/server/src/User/Controller/toolTipInfosUser.controller.ts
@@ -9,7 +9,7 @@ export async function userToolTip(req: FastifyRequest) {
 	const user = await getToolTipInfos(id);
 
 	if (!user) {
-		throw new ExpectedError(`Missing user.`);
+		throw new ExpectedError('userNotFound');
 	}
 
 	return user;

--- a/app/server/src/User/Routes/user.routes.ts
+++ b/app/server/src/User/Routes/user.routes.ts
@@ -3,9 +3,11 @@ import { FastifyInstance } from 'fastify';
 import { acceptGameRules } from '../Controller/acceptGameRules.controller.js';
 import { checkNameUser } from '../Controller/checkNameUser.controller.js';
 import { createUser } from '../Controller/createUser.controller.js';
+import { deleteUser } from '../Controller/deleteUser.controller.js';
 import { loginUser } from '../Controller/loginUser.controller.js';
 import { logoutUser } from '../Controller/logoutUser.controller.js';
 import { meUser } from '../Controller/meUser.controller.js';
+import { resetUser } from '../Controller/resetUser.controller.js';
 import { searchUsersByName } from '../Controller/searchUsersByName.controller.js';
 import { userToolTip } from '../Controller/toolTipInfosUser.controller.js';
 import {
@@ -17,6 +19,7 @@ import {
 import {
 	acceptGameRulesSchema,
 	changeUserPasswordSchema,
+	confirmActionSchema,
 	createUserResponseSchema,
 	createUserSchema,
 	loginResponseSchema,
@@ -73,6 +76,30 @@ export async function userRoutes(app: FastifyInstance) {
 			}
 		},
 		changeUserPassword
+	);
+
+	app.delete(
+		'/me/delete',
+		{
+			preHandler: [app.authenticate],
+			schema: {
+				tags: ['Users'],
+				body: confirmActionSchema
+			}
+		},
+		deleteUser
+	);
+
+	app.post(
+		'/me/reset',
+		{
+			preHandler: [app.authenticate],
+			schema: {
+				tags: ['Users'],
+				body: confirmActionSchema
+			}
+		},
+		resetUser
 	);
 	// Check name of account creation
 	app.get(

--- a/app/server/src/User/Schema/user.schema.ts
+++ b/app/server/src/User/Schema/user.schema.ts
@@ -90,3 +90,4 @@ export const changeUserPasswordSchema = z
 	});
 
 export type ChangeUserPasswordInput = z.infer<typeof changeUserPasswordSchema>;
+export const confirmActionSchema = z.object({ password: z.string() });

--- a/app/server/src/config/game.config.ts
+++ b/app/server/src/config/game.config.ts
@@ -6,6 +6,7 @@ interface DinozConfig {
 	maxLevel: number;
 	maxQuantity: number;
 	initialMaxLevel: number;
+	maxKeepSeedReincarnations: number;
 }
 
 interface ShopConfig {
@@ -43,7 +44,8 @@ const gameConfig: Record<GameEnv, GameConfig> = {
 		dinoz: {
 			maxLevel: 80,
 			maxQuantity: 18,
-			initialMaxLevel: 50
+			initialMaxLevel: 50,
+			maxKeepSeedReincarnations: 5
 		},
 		shop: {
 			dinozNumber: 30
@@ -72,7 +74,8 @@ const gameConfig: Record<GameEnv, GameConfig> = {
 		dinoz: {
 			maxLevel: 80,
 			maxQuantity: 18,
-			initialMaxLevel: 50
+			initialMaxLevel: 50,
+			maxKeepSeedReincarnations: 5
 		},
 		shop: {
 			dinozNumber: 30

--- a/packages/core/src/models/bank/constants.ts
+++ b/packages/core/src/models/bank/constants.ts
@@ -24,7 +24,7 @@ export function getTreasureTicketGoldValue(quantity: number, rateBps: number) {
 
 export const BANK_SAVING_RATE_SCALE = 10000;
 
-export const BANK_SAVING_MAX_DEPOSIT = 1_000_000;
+export const BANK_SAVING_MAX_DEPOSIT = 500_000;
 
 export const BANK_SAVING_PLANS = [
 	{
@@ -32,16 +32,8 @@ export const BANK_SAVING_PLANS = [
 		interestRateBps: 1000
 	},
 	{
-		durationDays: 14,
-		interestRateBps: 2500
-	},
-	{
-		durationDays: 21,
-		interestRateBps: 4000
-	},
-	{
 		durationDays: 30,
-		interestRateBps: 8000
+		interestRateBps: 5000
 	}
 ] as const;
 

--- a/packages/core/src/models/goals/goals.ts
+++ b/packages/core/src/models/goals/goals.ts
@@ -61,7 +61,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'The Pteroz Trophy is awarded to players who have defeated the strange Pteroz. It also unlocks the Pteroz, making it available to buy in the Dinoz Shop.',
 			FR: 'Le Trophée des Pteroz récompense les joueurs ayant vaincu le Ptéroz étrange, et donne accès aux Pteroz parmi les Dinoz disponibles dans la Boutique.',
 			DE: 'Die Trophäe der Pteroz ist eine Belohung für Spieler, die den seltsamen Pteroz besiegt haben. Damit habt ihr im Geschäft die Möglichkeit, Pteroz als neue Dinogattung zu kaufen.',
-			ES: 'El Trofeo DE los Teroz recompensa a los jugadores que hayan vencido al Teroz extraño. Asimismo, este objeto da acceso a la compra DE los Dinos Teroz EN la Tienda.'
+			ES: 'El Trofeo DE los Teroz recompensa a los jugadores que hayan vencido al Teroz extraño. Asimismo, este objeto da acceso a la compra de los Dinos Teroz en la Tienda.'
 		}
 	},
 	[StatTracking.HIPPO]: {
@@ -203,7 +203,7 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: "You helped Baobob to dispatch Taurus, the infamous Moueffe, to the depths of the Dark World. You're not ready to meet him again yet, although word of your courage is already spreading throughout Dinoland.",
-			FR: "Vous avez aidé Baobob à refouler le puissant Moueffe infernal Taurus dans les profondeurs du Monde Sombre. Vous n'êtes pas prêt DE le revoir, votre courage commence déjà à traverser les frontières DE Dinoland.",
+			FR: "Vous avez aidé Baobob à refouler le puissant Moueffe infernal Taurus dans les profondeurs du Monde Sombre. Vous n'êtes pas prêt de le revoir, votre courage commence déjà à traverser les frontières de Dinoland.",
 			DE: 'Du hast Bao Bob dabei geholfen, den mächtigen und teuflischen Moeffe Taurus zurück in die Tiefen der dunklen Welt zu schicken. Du bist nicht bereit, ihn wiederzusehen. Dein Mut überschreitet bereits die Grenzen von Dinoland.',
 			ES: 'Has ayudado a Baobob a enviar al poderoso e infernal Moueffe Taurus a las profundidades del Mundo Sombra. Las historias sobre esta hazaña ya han dado la vuelta a todo Dinoland.'
 		}
@@ -275,9 +275,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'This feather, a gift from a distant traveller, allows you to edit your presentation on your player profile.',
-			FR: "Cette plume, cadeau DE quelqu'un venu DE très loin, permet d'éditer la présentation DE la fiche joueur.",
+			FR: "Cette plume, cadeau de quelqu'un venu de très loin, permet d'éditer la présentation de la fiche joueur.",
 			DE: "Diese Feder ist ein Geschenk von jemandem, der von seeeehr weit her gekommen ist. Mit ihr kannst du das Spielerprofil bearbeiten und in den 'Roleplay'-Bereich gelangen, der sich im Forum befindet.",
-			ES: 'Esta pluma ES un regalo DE procedencia muy lejana. Permite editar la presentación DE la ficha del jugador.'
+			ES: 'Esta pluma es un regalo de procedencia muy lejana. Permite editar la presentación de la ficha del jugador.'
 		}
 	},
 	[StatTracking.KAURA]: {
@@ -349,16 +349,16 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'The Illustrated Mission Guidebook lets you see the list of missions which have been completed by your Dinoz, and which remain to be completed.',
 			FR: "Le Petit Missionnaire Illustré permet d'avoir accés à tout moment à la liste des missions effectuées et restant à faire pour vos Dinoz.",
 			DE: 'Das illustrierte Missionsbuch zeigt dir alle Missionen, die deine Dinoz bereits abgeschlossen oder noch vor sich haben.',
-			ES: 'El Pequeño Misionario Ilustrado te da acceso EN todo momento a la lista DE misiones efectuadas por tu Dino y las que le quedan por hacer..'
+			ES: 'El Pequeño Misionario Ilustrado te da acceso en todo momento a la lista de misiones efectuadas por tu Dino y las que le quedan por hacer..'
 		}
 	},
 	[StatTracking.PDA]: {
 		id: StatTracking.PDA,
 		name: {
 			EN: 'Diamantite Pebble',
-			FR: 'Pierre EN Diamantite Agglomérée',
+			FR: 'Pierre en Diamantite Agglomérée',
 			DE: 'Stein aus gepresstem Diamantit',
-			ES: 'Piedra EN Diamantito Aglomerado'
+			ES: 'Piedra en Diamantito Aglomerado'
 		},
 		rare: 0,
 		hidden: true,
@@ -371,9 +371,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'The Diamantite Pebble is a stone which is packed with a naturally occurring array of elements which, when combined under pressure, allow the owner to see all their dinoz at a glance. The diamantite, on the other hand, is only for show.',
-			FR: "La P.D.A. est une pierre remplie (chose surprenante) DE technologie formée naturellement et permettant à l'éleveur d'avoir un aperçu DE tous ses Dinoz EN un simple coup d'oeil. La Diamantite au contraire c'est juste pour la frime.",
+			FR: "La P.D.A. est une pierre remplie (chose surprenante) de technologie formée naturellement et permettant à l'éleveur d'avoir un aperçu de tous ses Dinoz en un simple coup d'oeil. La Diamantite au contraire c'est juste pour la frime.",
 			DE: 'Der Stein aus gepresstem Diamantit ist ein Stein, der mit natürlicher Technologie geformt wurde (was überraschend ist) und der den Züchtern erlaubt sich mit einem Blick eine Übersicht all seiner Dinoz zu verschaffen. Das Diamantit hingegen ist nur zum Angeben.',
-			ES: 'La PDA ES una piedra producida con una tecnología especial que permite al maestro que la posea tener una visión general DE todos sus Dinos. Lo del Diamantito ES sólo para chulear.'
+			ES: 'La PDA es una piedra producida con una tecnología especial que permite al maestro que la posea tener una visión general de todos sus Dinos. Lo del Diamantito es sólo para chulear.'
 		}
 	},
 	[StatTracking.DICARB]: {
@@ -454,7 +454,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Mandragore Doll',
 			FR: 'Poupée Mandragore',
 			DE: 'Mandragore-Puppe',
-			ES: 'Muñeco DE Mandrágora'
+			ES: 'Muñeco de Mandrágora'
 		},
 		rare: 0,
 		hidden: true,
@@ -467,9 +467,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'A doll in the likeness of Mandragore, which can be used as a voodoo doll, punching-bag or a pillow, as you choose.\tIt is in pretty poor condition, the previous owner must have taken their frustrations out on it on a regular basis.',
-			FR: "Une poupée à l'éffigie de Mandragore, elle peut servir DE poupée vaudou, punching-ball ou DE coussin, c'est au choix. Elle est EN piteuse état, l'ancien propriétaire a dû passer ses nerfs dessus assez souvent.",
+			FR: "Une poupée à l'éffigie de Mandragore, elle peut servir de poupée vaudou, punching-ball ou de coussin, c'est au choix. Elle est en piteuse état, l'ancien propriétaire a dû passer ses nerfs dessus assez souvent.",
 			DE: 'Die Puppe zeigt Mandragore da und kann als Voodoopuppe, Boxsack oder Kissen dienen - je nach Wetter und Laune. Sie ist in einem miserablen Zustand. Ihrem alten Besitzer müssen ziemlich oft die Nerven durchgegangen sein.',
-			ES: 'Un muñeco con la forma de Mandrágora puede servir como peluche o como cojín. Está EN muy mal estado, su antiguo dueño debió sufrir varias crisis DE nervios con él.'
+			ES: 'Un muñeco con la forma de Mandrágora puede servir como peluche o como cojín. Está en muy mal estado, su antiguo dueño debió sufrir varias crisis de nervios con él.'
 		}
 	},
 	[StatTracking.FMEDAL]: {
@@ -501,7 +501,7 @@ export const goals: Record<StatTracking, Goal> = {
 		name: {
 			EN: 'Smogs Medallion',
 			FR: 'Trophée des Smogs',
-			DE: '',
+			DE: 'Trophäe der Smogs',
 			ES: 'Trofeo de los Smogs'
 		},
 		rare: 0,
@@ -516,7 +516,7 @@ export const goals: Record<StatTracking, Goal> = {
 		description: {
 			EN: 'This medallion proves that you have finished the smog quest.',
 			FR: 'Ce trophée prouve que vous avez terminé la quête du Smog.',
-			DE: '',
+			DE: 'Diese Trophäe beweist, dass ihr die Smog-Quest abgeschlossen habt.',
 			ES: 'Este medallón prueba que has terminado la búsqueda del Smog.'
 		}
 	},
@@ -538,10 +538,10 @@ export const goals: Record<StatTracking, Goal> = {
 			}
 		],
 		description: {
-			EN: 'Grillée à la perfection et tamponnée par le Vendeur de Merguez lui-même, cette carte sacrée récompense les estomacs les plus endurants. Après avoir englouti un nombre indécent DE merguez, vous voilà promu au rang DE Grand Gourmand Officiel. Dorénavant, vos achats explosent les compteurs : x100 merguez d’un coup, parce que x5, c’est pour les amateurs.', // TODO: No translation available
-			FR: 'Grillée à la perfection et tamponnée par le Vendeur de Merguez lui-même, cette carte sacrée récompense les estomacs les plus endurants. Après avoir englouti un nombre indécent DE merguez, vous voilà promu au rang DE Grand Gourmand Officiel. Dorénavant, vos achats explosent les compteurs : x100 merguez d’un coup, parce que x5, c’est pour les amateurs.',
-			DE: 'Grillée à la perfection et tamponnée par le Vendeur de Merguez lui-même, cette carte sacrée récompense les estomacs les plus endurants. Après avoir englouti un nombre indécent DE merguez, vous voilà promu au rang DE Grand Gourmand Officiel. Dorénavant, vos achats explosent les compteurs : x100 merguez d’un coup, parce que x5, c’est pour les amateurs.', // TODO: No translation available
-			ES: 'Asada a la perfección y sellada por el Vendedor de Salchichas EN persona. Esta carta sagrada recompensa a los estómagos más resistentes. Después DE haber devorado una cantidad indecente DE salchichas, ahora has sido ascendido al rango DE Gran Glotón Oficial.'
+			EN: 'Grilled to perfection and stamped by the Merguez Vendor himself, this sacred card rewards the toughest stomachs. After devouring an indecent number of merguez sausages, you’ve now been promoted to the rank of Official Grand Gourmet. From now on, your purchases will blow the counters sky-high: x100 merguez at once, because x5 is for amateurs.',
+			FR: 'Grillée à la perfection et tamponnée par le Vendeur de Merguez lui-même, cette carte sacrée récompense les estomacs les plus endurants. Après avoir englouti un nombre indécent de merguez, vous voilà promu au rang de Grand Gourmand Officiel. Dorénavant, vos achats explosent les compteurs : x100 merguez d’un coup, parce que x5, c’est pour les amateurs.',
+			DE: 'Perfekt gegrillt und vom Merguez-Verkäufer höchstpersönlich abgestempelt, belohnt diese heilige Karte die ausdauerndsten Mägen. Nachdem ihr eine unanständige Menge Merguez verschlungen habt, wurdet ihr nun in den Rang des Offiziellen Großen Feinschmeckers erhoben. Von nun an sprengen eure Einkäufe alle Zähler: x100 Merguez auf einmal, denn x5 ist etwas für Amateure.',
+			ES: 'Asada a la perfección y sellada por el Vendedor de Salchichas en persona. Esta carta sagrada recompensa a los estómagos más resistentes. Después DE haber devorado una cantidad indecente DE salchichas, ahora has sido ascendido al rango DE Gran Glotón Oficial.'
 		}
 	},
 	[StatTracking.PAC]: {
@@ -563,9 +563,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'The Scroll of Compiled Abilities is a sophisticated artifact that lists instantly all the skills mastered by your Dinoz. It gives a clear overview and a detailed breakdown of each talent in one look.',
-			FR: "Le Parchemin des Aptitudes Compilées est un artefact élégant qui répertorie instantanément l'ensemble des compétences maîtrisées par vos Dinoz, offrant un aperçu clair et détaillé DE leurs talents EN un seul regard.",
+			FR: "Le Parchemin des Aptitudes Compilées est un artefact élégant qui répertorie instantanément l'ensemble des compétences maîtrisées par vos Dinoz, offrant un aperçu clair et détaillé de leurs talents en un seul regard.",
 			DE: 'Die Schriftrolle der Gesammelten Fähigkeiten ist ein elegantes Artefakt, das alle von deinen Dinoz beherrschten Fähigkeiten auflistet und dir auf einen Blick eine klare und detaillierte Übersicht über deren Talente verschafft.',
-			ES: 'El Pergamino de Competencias Compiladas ES un artefacto elegante que registra instantáneamente todas las competencias dominadas por tus Dinos, ofreciendo una visión clara y detallada DE sus talentos DE un solo vistazo.'
+			ES: 'El Pergamino de Competencias Compiladas ES un artefacto elegante que registra instantáneamente todas las competencias dominadas por tus Dinos, ofreciendo una visión clara y detallada de sus talentos de un solo vistazo.'
 		}
 	},
 	// DAILY STATS
@@ -854,7 +854,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'What kind of adventurer are you?',
 					FR: "Quel type d'aventurier êtes-vous ?",
 					DE: 'So ein Typ Abenteurer bist du',
-					ES: '¿Qué tipo DE aventurero eres?'
+					ES: '¿Qué tipo de aventurero eres?'
 				}
 			},
 			{
@@ -989,9 +989,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Dinoland Legend',
-					FR: 'Légende DE Dinoland',
+					FR: 'Légende de Dinoland',
 					DE: 'Dinoland-Legende',
-					ES: 'Leyenda DE Dinoland'
+					ES: 'Leyenda de Dinoland'
 				}
 			}
 		],
@@ -999,7 +999,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'What kind of adventurer are you?',
 			FR: "Quel type d'aventurier êtes-vous?",
 			DE: 'So ein Typ Abenteurer bist du',
-			ES: '¿Qué tipo DE aventurero eres?'
+			ES: '¿Qué tipo de aventurero eres?'
 		}
 	},
 	[StatTracking.DEATHS]: {
@@ -1018,15 +1018,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_barbare.gif',
 				title: {
 					EN: 'Spirit Dinoz master',
-					FR: 'Revenant DE loin',
+					FR: 'Revenant de loin',
 					DE: 'Wiedergänger',
 					ES: 'Mala Hierba'
 				},
 				description: {
 					EN: 'How many times have you died in combat?',
-					FR: 'Combien DE fois êtes-vous mort au combat ?',
+					FR: 'Combien de fois êtes-vous mort au combat ?',
 					DE: 'So oft bist du im Kampf gefallen',
-					ES: 'Cantidad DE veces que has muerto EN combate'
+					ES: 'Cantidad de veces que has muerto EN combate'
 				}
 			},
 			{
@@ -1072,9 +1072,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'How many times have you died in combat?',
-			FR: 'Combien DE fois êtes-vous mort au combat ?',
+			FR: 'Combien de fois êtes-vous mort au combat ?',
 			DE: 'So oft bist du im Kampf gefallen.',
-			ES: 'Cantidad DE veces que has muerto EN combate'
+			ES: 'Cantidad de veces que has muerto en combate'
 		}
 	},
 	[StatTracking.P_DAYS]: {
@@ -1083,7 +1083,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Education',
 			FR: 'Eleveur',
 			DE: 'Schüler',
-			ES: 'Criador DE Dinos'
+			ES: 'Criador de Dinos'
 		},
 		rare: 2,
 		unlocks: [
@@ -1099,9 +1099,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of days spent on the site.',
-					FR: 'Nombre DE jours DE présence sur le site.',
+					FR: 'Nombre de jours de présence sur le site.',
 					DE: 'Anzahl der in Dinoland verbrachten Tage',
-					ES: 'Cantidad DE días presente EN el sitio.'
+					ES: 'Cantidad de días presente en el sitio.'
 				}
 			},
 			{
@@ -1121,7 +1121,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Gifted Preacher',
 					FR: 'Prêcheur accompli',
 					DE: 'Vollkommener Prediger',
-					ES: 'Profeta EN su Tierra'
+					ES: 'Profeta en su Tierra'
 				}
 			},
 			{
@@ -1167,9 +1167,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of days spent on the site',
-			FR: 'Nombre DE jours DE présence sur le site',
+			FR: 'Nombre de jours de présence sur le site',
 			DE: 'Anzahl der in Dinoland verbrachten Tage',
-			ES: 'Cantidad DE días presente EN el sitio'
+			ES: 'Cantidad de días presente en el sitio'
 		}
 	},
 	[StatTracking.LVL_UP]: {
@@ -1178,7 +1178,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Trainer',
 			FR: 'Entraîneur',
 			DE: 'Trainer',
-			ES: 'Entrenador DE Dinos'
+			ES: 'Entrenador de Dinos'
 		},
 		rare: 2,
 		unlocks: [
@@ -1194,9 +1194,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of Level-ups carried out.',
-					FR: 'Nombre DE level-up réalisés.',
+					FR: 'Nombre de level-up réalisés.',
 					DE: 'Anzahl der Level-Ups',
-					ES: 'Cantidad DE subida DE niveles que has realizado.'
+					ES: 'Cantidad de subida de niveles que has realizado.'
 				}
 			},
 			{
@@ -1206,7 +1206,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Apprentice Trainer',
 					FR: 'Apprenti entraineur',
 					DE: 'Trainer-Novize',
-					ES: 'Aprendiz DE Entrenador'
+					ES: 'Aprendiz de Entrenador'
 				}
 			},
 			{
@@ -1262,18 +1262,18 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Level-ups carried out',
-			FR: 'Nombre DE levelup réalisés',
+			FR: 'Nombre de levelup réalisés',
 			DE: 'Anzahl der Level-Ups',
-			ES: 'Cantidad DE subidas DE niveles que has realizado'
+			ES: 'Cantidad de subidas de niveles que has realizado'
 		}
 	},
 	[StatTracking.KILL_M]: {
 		id: StatTracking.KILL_M,
 		name: {
 			EN: 'Monster Killer',
-			FR: 'Tueur DE monstres',
+			FR: 'Tueur de monstres',
 			DE: 'Monsterjäger',
-			ES: 'Terror DE monstruos'
+			ES: 'Terror de monstruos'
 		},
 		rare: 2,
 		unlocks: [
@@ -1283,15 +1283,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_monster.gif',
 				title: {
 					EN: 'Monster Hunter',
-					FR: 'Balayeur DE restes',
+					FR: 'Balayeur de restes',
 					DE: 'Freizeit-Jäger',
-					ES: 'Barredor DE Restos'
+					ES: 'Barredor de Restos'
 				},
 				description: {
 					EN: 'Number of monsters killed on your adventures.',
-					FR: 'Nombre DE monstres tués durant vos aventures.',
+					FR: 'Nombre DdeE monstres tués durant vos aventures.',
 					DE: 'Anzahl der von dir getöteten Monster',
-					ES: 'Cantidad DE monstruos que mataste EN tus aventuras.'
+					ES: 'Cantidad de monstruos que mataste en tus aventuras.'
 				}
 			},
 			{
@@ -1301,7 +1301,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Scourge of Beasts',
 					FR: 'Bourreau des corps',
 					DE: 'Leichenschinder',
-					ES: 'Cazador DE Monstruos'
+					ES: 'Cazador de Monstruos'
 				}
 			},
 			{
@@ -1309,7 +1309,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Monster Killer',
-					FR: 'Chasseur DE monstres',
+					FR: 'Chasseur de monstres',
 					DE: 'Monsterjäger',
 					ES: 'Mercenario'
 				}
@@ -1321,7 +1321,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Monster Annihilator',
 					FR: 'Tueur barbare',
 					DE: 'Barbarentöter',
-					ES: 'Devorador DE Monstruos'
+					ES: 'Devorador de Monstruos'
 				}
 			},
 			{
@@ -1329,7 +1329,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Giant Killer',
-					FR: 'Annihilateur DE géant',
+					FR: 'Annihilateur de géant',
 					DE: 'Zerschmetterer der Riesen',
 					ES: 'Aniquilador'
 				}
@@ -1339,7 +1339,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Barbarian Destroyer',
-					FR: 'Dévastateur DE colosses',
+					FR: 'Dévastateur de colosses',
 					DE: 'Verheerer der Kolosse',
 					ES: 'Practicante del F.U.A.'
 				}
@@ -1349,7 +1349,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Reaper of Titans',
-					FR: 'Exterminateur DE Titans',
+					FR: 'Exterminateur de Titans',
 					DE: 'Vernichter der Titanen',
 					ES: 'Matador'
 				}
@@ -1361,7 +1361,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'King of Chaos',
 					FR: 'Roi du chaos',
 					DE: 'König des Chaos',
-					ES: 'Devorador DE Monstruos'
+					ES: 'Devorador de Monstruos'
 				}
 			},
 			{
@@ -1369,24 +1369,24 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'God of Destruction',
-					FR: 'Dieu DE la destruction',
+					FR: 'Dieu de la destruction',
 					DE: 'Gott der Zerstörung',
-					ES: 'Exterminador DE Monstruos'
+					ES: 'Exterminador de Monstruos'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of monsters killed on your adventures',
-			FR: 'Nombre DE monstres tués durant vos aventures',
+			FR: 'Nombre de monstres tués durant vos aventures',
 			DE: 'Anzahl der von dir getöteten Monster',
-			ES: 'Cantidad DE monstruos que mataste EN tus aventuras'
+			ES: 'Cantidad de monstruos que mataste en tus aventuras'
 		}
 	},
 	[StatTracking.KILL_D]: {
 		id: StatTracking.KILL_D,
 		name: {
 			EN: 'Dinoz Challenger',
-			FR: 'Challenger DE Dinoz',
+			FR: 'Challenger de Dinoz',
 			DE: 'Dinoz-Herausforderer',
 			ES: 'Gladiador'
 		},
@@ -1404,9 +1404,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of Dinoz defeated in events.',
-					FR: 'Nombre DE Dinoz vaincus durant les évènements',
+					FR: 'Nombre de Dinoz vaincus durant les évènements',
 					DE: 'Anzahl der während Events besiegter Dinoz',
-					ES: 'Cantidad DE Dinos vencidos EN los eventos'
+					ES: 'Cantidad de Dinos vencidos en los eventos'
 				}
 			},
 			{
@@ -1454,17 +1454,17 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'God of Death',
-					FR: 'Dieu DE la mort',
+					FR: 'Dieu de la mort',
 					DE: 'Gott des Todes',
-					ES: 'Dios DE la Muerte'
+					ES: 'Dios de la Muerte'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of Dinoz defeated in events',
-			FR: 'Nombre DE Dinoz vaincus durant les évènements',
+			FR: 'Nombre de Dinoz vaincus durant les évènements',
 			DE: 'Anzahl der während Events besiegter Dinoz',
-			ES: 'Cantidad DE Dinos vencidos EN los eventos'
+			ES: 'Cantidad de Dinos vencidos en los eventos'
 		}
 	},
 	[StatTracking.HEAL_PV]: {
@@ -1489,9 +1489,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'How many HP have you regained?',
-					FR: 'Combien DE pv avez vous regagné ?',
+					FR: 'Combien de pv avez vous regagné ?',
 					DE: 'Soviele Lebenspunkte hast du wiedergewonnen',
-					ES: 'La cantidad DE puntos DE vida que has recuperado'
+					ES: 'La cantidad de puntos de vida que has recuperado'
 				}
 			},
 			{
@@ -1547,9 +1547,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'How many HP have you regained?',
-			FR: 'Combien DE pv avez vous regagnés ?',
+			FR: 'Combien de pv avez vous regagnés ?',
 			DE: 'Soviele Lebenspunkte hast du wiedergewonnen',
-			ES: 'La cantidad DE puntos DE vida que has recuperado'
+			ES: 'La cantidad de puntos de vida que has recuperado'
 		}
 	},
 	[StatTracking.UP_WOOD]: {
@@ -1558,7 +1558,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Wood Specialist',
 			FR: 'Spécialiste du bois',
 			DE: 'Holzspezialist',
-			ES: 'Especialista DE Madera'
+			ES: 'Especialista de Madera'
 		},
 		rare: 0,
 		unlocks: [
@@ -1570,13 +1570,13 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Tiny Acorn',
 					FR: 'Jeune pi-mousse',
 					DE: 'Jungspund',
-					ES: 'Oledor DE Madera'
+					ES: 'Oledor de Madera'
 				},
 				description: {
 					EN: 'Number of Wood level-ups.',
-					FR: "Nombre DE up réalisés sur l'élément bois.",
+					FR: "Nombre de up réalisés sur l'élément bois.",
 					DE: 'Anzahl der Level-Ups beim Holz-Element',
-					ES: 'Cantidad DE subidas DE nivel realizadas EN elemento madera'
+					ES: 'Cantidad de subidas de nivel realizadas en elemento madera'
 				}
 			},
 			{
@@ -1586,7 +1586,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Young Shoot',
 					FR: 'Belle au bois dormant',
 					DE: 'Meister Eder',
-					ES: 'Recogedor DE Ramas'
+					ES: 'Recogedor de Ramas'
 				}
 			},
 			{
@@ -1594,9 +1594,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Sturdy Oak',
-					FR: 'Gueule DE bois',
+					FR: 'Gueule de bois',
 					DE: 'Erfahrener Schreiner',
-					ES: 'Ayudante DE Carpintero'
+					ES: 'Ayudante de Carpintero'
 				}
 			},
 			{
@@ -1622,9 +1622,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Wood level-ups',
-			FR: "Nombre DE up réalisés sur l'élément bois",
+			FR: "Nombre de up réalisés sur l'élément bois",
 			DE: 'Anzahl der Level-Ups beim Holz-Element',
-			ES: 'Cantidad DE subidas DE nivel realizadas EN elemento madera'
+			ES: 'Cantidad de subidas de nivel realizadas en elemento madera'
 		}
 	},
 	[StatTracking.UP_FIRE]: {
@@ -1633,7 +1633,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Fire Specialist',
 			FR: 'Spécialiste du feu',
 			DE: 'Feuerspezialist',
-			ES: 'Especialista DE Fuego'
+			ES: 'Especialista de Fuego'
 		},
 		rare: 0,
 		unlocks: [
@@ -1649,9 +1649,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of Fire level-ups.',
-					FR: "Nombre DE up réalisés sur l'élément feu.",
+					FR: "Nombre de up réalisés sur l'élément feu.",
 					DE: 'Anzahl der Level-Ups beim Feuer-Element',
-					ES: 'Cantidad DE subidas DE nivel realizadas EN elemento fuego'
+					ES: 'Cantidad de subidas de nivel realizadas en elemento fuego'
 				}
 			},
 			{
@@ -1661,7 +1661,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Firestarter',
 					FR: 'Brasier des ténèbres',
 					DE: 'Flamme der Finsternis',
-					ES: 'Flama DE Vela'
+					ES: 'Flama de Vela'
 				}
 			},
 			{
@@ -1697,16 +1697,16 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Fire level-ups',
-			FR: "Nombre DE up réalisés sur l'élément feu",
+			FR: "Nombre de up réalisés sur l'élément feu",
 			DE: 'Anzahl der Level-Ups beim Feuer-Element',
-			ES: 'Cantidad DE subidas DE nivel realizadas EN elemento fuego'
+			ES: 'Cantidad de subidas de nivel realizadas en elemento fuego'
 		}
 	},
 	[StatTracking.UP_LIGHTNING]: {
 		id: StatTracking.UP_LIGHTNING,
 		name: {
 			EN: 'Lightning Specialist',
-			FR: 'Spécialiste DE la foudre',
+			FR: 'Spécialiste de la foudre',
 			DE: 'Blitzspezialist',
 			ES: 'Especialista del Rayo'
 		},
@@ -1724,9 +1724,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of Lightning level-ups.',
-					FR: "Nombre DE up réalisés sur l'élément foudre.",
+					FR: "Nombre de up réalisés sur l'élément foudre.",
 					DE: 'Anzahl der Level-Ups beim Blitz-Element',
-					ES: 'Cantidad DE subidas DE nivel realizadas EN elemento rayo'
+					ES: 'Cantidad de subidas de nivel realizadas en elemento rayo'
 				}
 			},
 			{
@@ -1734,7 +1734,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Overload',
-					FR: 'Excès DE vitesse',
+					FR: 'Excès de vitesse',
 					DE: 'Überladung',
 					ES: 'Ráfaga'
 				}
@@ -1744,7 +1744,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Caged Lightning',
-					FR: 'Eclair DE génie',
+					FR: 'Eclair de génie',
 					DE: 'Blitzschlag',
 					ES: 'Flash'
 				}
@@ -1772,16 +1772,16 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Lightning level-ups',
-			FR: "Nombre DE up réalisés sur l'élément foudre",
+			FR: "Nombre de up réalisés sur l'élément foudre",
 			DE: 'Anzahl der Level-Ups beim Blitz-Element',
-			ES: 'Cantidad DE subidas DE nivel realizadas EN elemento rayo'
+			ES: 'Cantidad de subidas de nivel realizadas en elemento rayo'
 		}
 	},
 	[StatTracking.UP_AIR]: {
 		id: StatTracking.UP_AIR,
 		name: {
 			EN: 'Air Specialist',
-			FR: "Spécialiste DE l'air",
+			FR: "Spécialiste de l'air",
 			DE: 'Luftspezialist',
 			ES: 'Especialista del Aire'
 		},
@@ -1799,9 +1799,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of Air level-ups.',
-					FR: "Nombre DE up réalisés sur l'élément air.",
+					FR: "Nombre de up réalisés sur l'élément air.",
 					DE: 'Anzahl der Level-Ups beim Luft-Element',
-					ES: 'Cantidad DE subidas DE nivel realizadas EN elemento aire.'
+					ES: 'Cantidad de subidas de nivel realizadas en elemento aire.'
 				}
 			},
 			{
@@ -1847,18 +1847,18 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Air level-ups',
-			FR: "Nombre DE up réalisés sur l'élément air",
+			FR: "Nombre de up réalisés sur l'élément air",
 			DE: 'Anzahl der Level-Ups beim Luft-Element',
-			ES: 'Cantidad DE subidas DE nivel realizadas EN elemento aire'
+			ES: 'Cantidad de subidas de nivel realizadas en elemento aire'
 		}
 	},
 	[StatTracking.UP_WATER]: {
 		id: StatTracking.UP_WATER,
 		name: {
 			EN: 'Water Specialist',
-			FR: "Spécialiste DE l'eau",
+			FR: "Spécialiste de l'eau",
 			DE: 'Wasserspezialist',
-			ES: 'Especialista EN Agua'
+			ES: 'Especialista en Agua'
 		},
 		rare: 0,
 		unlocks: [
@@ -1868,15 +1868,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_water.gif',
 				title: {
 					EN: 'Rubber Duck',
-					FR: 'Canard DE bain',
+					FR: 'Canard de bain',
 					DE: 'Gummiente',
 					ES: 'Pez'
 				},
 				description: {
 					EN: 'Number of Water level-ups.',
-					FR: "Nombre DE up réalisés sur l'élément eau.",
+					FR: "Nombre de up réalisés sur l'élément eau.",
 					DE: 'Anzahl der Level-Ups beim Wasser-Element',
-					ES: 'Cantidad DE subidas DE nivel realizadas EN elemento agua'
+					ES: 'Cantidad de subidas de nivel realizadas en elemento agua'
 				}
 			},
 			{
@@ -1894,7 +1894,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Heart of Ice',
-					FR: 'Coeur DE glace',
+					FR: 'Coeur de glace',
 					DE: 'Herz aus Eis',
 					ES: 'Marea Alta'
 				}
@@ -1922,16 +1922,16 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of Water level-ups',
-			FR: "Nombre DE up réalisés sur l'élément eau",
+			FR: "Nombre de up réalisés sur l'élément eau",
 			DE: 'Anzahl der Level-Ups beim Wasser-Element',
-			ES: 'Cantidad DE subidas DE nivel realizadas EN elemento agua'
+			ES: 'Cantidad de subidas de nivel realizadas en elemento agua'
 		}
 	},
 	[StatTracking.BROKEN_SHOVEL]: {
 		id: StatTracking.BROKEN_SHOVEL,
 		name: {
 			EN: 'Shovel Smasher',
-			FR: 'Casseur DE pelles',
+			FR: 'Casseur de pelles',
 			DE: 'Schaufelzerbrecher',
 			ES: 'Rompe-palas'
 		},
@@ -1943,15 +1943,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_digger.gif',
 				title: {
 					EN: 'Earthworm',
-					FR: 'Ver DE terre',
+					FR: 'Ver de terre',
 					DE: 'Regenwurm',
 					ES: 'Gusano'
 				},
 				description: {
 					EN: 'Number of broken shovels.',
-					FR: 'Nombre DE pelles cassées.',
+					FR: 'Nombre de pelles cassées.',
 					DE: 'Anzahl der von dir zerbrochenen Schaufeln',
-					ES: 'Cantidad DE palas rotas.'
+					ES: 'Cantidad de palas rotas.'
 				}
 			},
 			{
@@ -1971,7 +1971,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Craftsman Miner',
 					FR: 'Galibot',
 					DE: 'Bergmann',
-					ES: 'Ayudante DE Minero'
+					ES: 'Ayudante de Minero'
 				}
 			},
 			{
@@ -1999,7 +1999,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Manic Miner',
-					FR: 'Ravineur DE légende',
+					FR: 'Ravineur de légende',
 					DE: 'Legendärer Buddler',
 					ES: 'Escavador tectónico'
 				}
@@ -2021,15 +2021,15 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Subterranean Master',
 					FR: 'Maître des profondeurs',
 					DE: 'Meister der Tiefen',
-					ES: 'Dios DE las Profundidades'
+					ES: 'Dios de las Profundidades'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of broken shovels',
-			FR: 'Nombre DE pelles cassées',
+			FR: 'Nombre de pelles cassées',
 			DE: 'Anzahl der von dir zerbrochenen Schaufeln',
-			ES: 'Cantidad DE palas rotas'
+			ES: 'Cantidad de palas rotas'
 		}
 	},
 	[StatTracking.CHASSE]: {
@@ -2050,13 +2050,13 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Dinoville Hunt Subscriber',
 					FR: 'Galinette Cendrée',
 					DE: 'Frischling',
-					ES: 'Colocador DE Trampas'
+					ES: 'Colocador de Trampas'
 				},
 				description: {
-					EN: "Nombre d'actions DE chasses réalisées.",
-					FR: "Nombre d'actions DE chasses réalisées.",
+					EN: "Nombre d'actions de chasses réalisées.",
+					FR: "Nombre d'actions de chasses réalisées.",
 					DE: 'Anzahl der durchgeführten Jagden',
-					ES: 'Cantidad DE cazas realizadas.'
+					ES: 'Cantidad de cazas realizadas.'
 				}
 			},
 			{
@@ -2066,7 +2066,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Reader of Hunting, Shooting, Fishing etc.',
 					FR: "Champion d'appeau",
 					DE: 'Waidmann',
-					ES: 'Aprendiz DE Cazador'
+					ES: 'Aprendiz de Cazador'
 				}
 			},
 			{
@@ -2104,7 +2104,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'King of the Hunt',
-					FR: 'Roi DE la chasse',
+					FR: 'Roi de la chasse',
 					DE: 'König der Jagd',
 					ES: 'Rey Cazador'
 				}
@@ -2114,17 +2114,17 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'God of the Hunt',
-					FR: 'Dieu DE la chasse',
+					FR: 'Dieu de la chasse',
 					DE: 'Gott der Jagd',
-					ES: 'Dios DE la Caza'
+					ES: 'Dios de la Caza'
 				}
 			}
 		],
 		description: {
 			EN: "Number of times you've set out to kill stuff!",
-			FR: "Nombre d'actions DE chasses réalisées",
+			FR: "Nombre d'actions de chasses réalisées",
 			DE: 'Anzahl der von dir durchgeführten Jagden',
-			ES: 'Cantidad DE cazas realizadas'
+			ES: 'Cantidad de cazas realizadas'
 		}
 	},
 	[StatTracking.CUEILLE]: {
@@ -2149,9 +2149,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of harvesting operations carried out.',
-					FR: "Nombre d'actions DE cueillette réalisées.",
+					FR: "Nombre d'actions de cueillette réalisées.",
 					DE: 'Anzahl der von dir durchgeführten Ernten',
-					ES: 'Cantidad DE recolecciones realizadas.'
+					ES: 'Cantidad de recolecciones realizadas.'
 				}
 			},
 			{
@@ -2159,7 +2159,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Evil Herb Collector',
-					FR: 'Ramasseur DE mauvaises herbes',
+					FR: 'Ramasseur de mauvaises herbes',
 					DE: 'Unkrautjäter',
 					ES: 'Recolector Aficionado'
 				}
@@ -2201,7 +2201,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'King of the Harvest',
 					FR: 'Roi des récoltes',
 					DE: 'König der Ernte',
-					ES: 'Rey DE la Cosecha'
+					ES: 'Rey de la Cosecha'
 				}
 			},
 			{
@@ -2211,15 +2211,15 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'God of the Harvest',
 					FR: 'Dieu des récoltes',
 					DE: 'Gott der Ernte',
-					ES: 'Dios DE la Cosecha'
+					ES: 'Dios de la Cosecha'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of harvesting operations carried out',
-			FR: "Nombre d'actions DE cueillette réalisées",
+			FR: "Nombre d'actions de cueillette réalisées",
 			DE: 'Anzahl der von dir durchgeführten Ernten',
-			ES: 'Cantidad DE recolecciones realizadas'
+			ES: 'Cantidad de recolecciones realizadas'
 		}
 	},
 	[StatTracking.FISH]: {
@@ -2240,13 +2240,13 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Line Fisherman',
 					FR: 'Pêcheur à la ligne',
 					DE: 'Kescher',
-					ES: 'Ayudante DE Pescador'
+					ES: 'Ayudante de Pescador'
 				},
 				description: {
 					EN: 'Number of fishing trips.',
-					FR: "Nombre d'actions DE pêche réalisées.",
+					FR: "Nombre d'actions de pêche réalisées.",
 					DE: 'Anzahl deiner Angelausflüge',
-					ES: 'Cantidad DE pescas realizadas.'
+					ES: 'Cantidad de pescas realizadas.'
 				}
 			},
 			{
@@ -2264,7 +2264,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Deadliest Catch',
-					FR: 'Pêcheur EN haute mer',
+					FR: 'Pêcheur en haute mer',
 					DE: 'Hochseefischer',
 					ES: 'Pescador'
 				}
@@ -2276,7 +2276,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Fishing with Dynamite',
 					FR: 'Pêcheur à la dynamite',
 					DE: 'Dynamit-Angler',
-					ES: 'Pescador DE Río'
+					ES: 'Pescador de Río'
 				}
 			},
 			{
@@ -2286,7 +2286,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Ultimate Fisherman',
 					FR: 'Pêcheur ultime',
 					DE: 'Ultimativer Angler',
-					ES: 'Pescador DE Alta Mar'
+					ES: 'Pescador de Alta Mar'
 				}
 			},
 			{
@@ -2294,9 +2294,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'King Fisherman',
-					FR: 'Roi DE la Pêche',
+					FR: 'Roi de la Pêche',
 					DE: 'König des Angelns',
-					ES: 'Rey DE la Pesca'
+					ES: 'Rey de la Pesca'
 				}
 			},
 			{
@@ -2304,17 +2304,17 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'God of Fishing',
-					FR: 'Dieu DE la Pêche',
+					FR: 'Dieu de la Pêche',
 					DE: 'Gott des Angelns',
-					ES: 'Dios DE la Pesca'
+					ES: 'Dios de la Pesca'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of fishing trips',
-			FR: "Nombre d'actions DE pêche réalisées",
+			FR: "Nombre d'actions de pêche réalisées",
 			DE: 'Anzahl deiner Angelausflüge',
-			ES: 'Cantidad DE pescas realizadas'
+			ES: 'Cantidad de pescas realizadas'
 		}
 	},
 	[StatTracking.ENERGY]: {
@@ -2341,7 +2341,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Number of actions carried out which regenerate energy.',
 					FR: "Nombre d'actions d'énergétisation réalisées.",
 					DE: 'Anzahl der Energizer-Aktionen',
-					ES: 'Cantidad DE energizaciones realizadas.'
+					ES: 'Cantidad de energizaciones realizadas.'
 				}
 			},
 			{
@@ -2369,7 +2369,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Fission Researcher',
-					FR: 'Chercheur EN fission',
+					FR: 'Chercheur en fission',
 					DE: 'Atomforscher',
 					ES: 'Maestro Atómico'
 				}
@@ -2389,9 +2389,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'King of Fusion',
-					FR: 'Roi DE la fusion',
+					FR: 'Roi de la fusion',
 					DE: 'König der Fusion',
-					ES: 'Rey DE la Fusión'
+					ES: 'Rey de la Fusión'
 				}
 			},
 			{
@@ -2399,9 +2399,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: 'God of Fusion',
-					FR: 'Dieu DE la fusion',
+					FR: 'Dieu de la fusion',
 					DE: 'Gott der Fusion',
-					ES: 'Dios DE la Fusión'
+					ES: 'Dios de la Fusión'
 				}
 			}
 		],
@@ -2409,7 +2409,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Number of actions carried out which regenerate energy',
 			FR: "Nombre d'actions d'énergétisation réalisées",
 			DE: 'Anzahl der Energizer-Aktionen',
-			ES: 'Cantidad DE energizaciones realizadas'
+			ES: 'Cantidad de energizaciones realizadas'
 		}
 	},
 	[StatTracking.SEEK]: {
@@ -2428,15 +2428,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_fouille.gif',
 				title: {
 					EN: 'Pebble Collector',
-					FR: 'Ramasseur DE cailloux',
+					FR: 'Ramasseur de cailloux',
 					DE: 'Kieswühler',
-					ES: 'Recogedor DE piedritas'
+					ES: 'Recogedor de piedritas'
 				},
 				description: {
 					EN: 'Number of scavenges carried out.',
-					FR: "Nombre d'actions DE fouilles réalisées.",
+					FR: "Nombre d'actions de fouilles réalisées.",
 					DE: 'Anzahl der von dir ausgeführten Grabungen',
-					ES: 'Cantidad DE excavaciones realizadas.'
+					ES: 'Cantidad de excavaciones realizadas.'
 				}
 			},
 			{
@@ -2454,7 +2454,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Ruin Fan',
-					FR: 'Amateur DE ruines',
+					FR: 'Amateur de ruines',
 					DE: 'Ruinennovize',
 					ES: 'Excavador profesional'
 				}
@@ -2466,7 +2466,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Documented Architect',
 					FR: 'Archéologue documenté',
 					DE: 'Diplomierter Archäologe',
-					ES: 'Maestro DE excavaciones'
+					ES: 'Maestro de excavaciones'
 				}
 			},
 			{
@@ -2474,7 +2474,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Treasure Inventor',
-					FR: 'Inventeur DE trésor',
+					FR: 'Inventeur de trésor',
 					DE: 'Schatzfinder',
 					ES: 'Buscatesoros'
 				}
@@ -2502,9 +2502,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of scavenges carried out',
-			FR: "Nombre d'actions DE fouilles réalisées",
+			FR: "Nombre d'actions de fouilles réalisées",
 			DE: 'Anzahl der von dir ausgeführten Grabungen',
-			ES: 'Cantidad DE excavaciones realizadas'
+			ES: 'Cantidad de excavaciones realizadas'
 		}
 	},
 	[StatTracking.MARKET]: {
@@ -2523,15 +2523,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_market.gif',
 				title: {
 					EN: 'Soul of Camelot',
-					FR: 'Âme DE camelot',
+					FR: 'Âme de camelot',
 					DE: 'Seele von Camelot',
 					ES: 'Vendedor Debutante'
 				},
 				description: {
 					EN: 'Number of sales made at the market.',
-					FR: 'Nombre DE ventes conclues au marché.',
+					FR: 'Nombre de ventes conclues au marché.',
 					DE: 'Anzahl der auf dem Markt verkauften Artikel',
-					ES: 'Cantidad DE ventas EN el Mercado.'
+					ES: 'Cantidad de ventas en el Mercado.'
 				}
 			},
 			{
@@ -2569,9 +2569,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Dinoz Broker',
-					FR: 'Négociant EN Dinoz',
+					FR: 'Négociant en Dinoz',
 					DE: 'Gordon Dinoz',
-					ES: 'Proveedor DE Dinos'
+					ES: 'Proveedor de Dinos'
 				}
 			},
 			{
@@ -2591,15 +2591,15 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Traffick-King',
 					FR: 'Roi Trafiquant',
 					DE: 'König der Verschieber',
-					ES: 'Traficante DE Dinos'
+					ES: 'Traficante de Dinos'
 				}
 			}
 		],
 		description: {
 			EN: 'Number of sales made at the market',
-			FR: 'Nombre DE ventes conclues au marché',
+			FR: 'Nombre de ventes conclues au marché',
 			DE: 'Anzahl der auf dem Markt verkauften Artikel',
-			ES: 'Cantidad DE ventas EN el Mercado'
+			ES: 'Cantidad de ventas en el Mercado'
 		}
 	},
 	[StatTracking.S_BUYER]: {
@@ -2624,9 +2624,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of purchases made in the shop',
-					FR: "Nombre d'objet acquis EN boutique",
+					FR: "Nombre d'objet acquis en boutique",
 					DE: 'Anzahl der in Geschäften gekauften Artikel',
-					ES: 'Cantidad DE objetos adquiridos EN la tienda'
+					ES: 'Cantidad de objetos adquiridos en la tienda'
 				}
 			},
 			{
@@ -2674,7 +2674,7 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 1,
 				title: {
 					EN: 'Caveat Emptor',
-					FR: 'Géant DE la consommation',
+					FR: 'Géant de la consommation',
 					DE: 'Ungezügelter Konsument',
 					ES: 'Magnate'
 				}
@@ -2692,9 +2692,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of purchases made in the shop',
-			FR: "Nombre d'objets acquis EN boutique",
+			FR: "Nombre d'objets acquis en boutique",
 			DE: 'Anzahl der in Geschäften gekauften Artikel',
-			ES: 'Cantidad DE objetos adquiridos EN la tienda'
+			ES: 'Cantidad de objetos adquiridos en la tienda'
 		}
 	},
 	[StatTracking.CLANS]: {
@@ -2720,9 +2720,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of clans this player has appeared in.',
-					FR: 'Nombre DE clans dans lequel le joueur a été aperçu.',
+					FR: 'Nombre de clans dans lequel le joueur a été aperçu.',
 					DE: 'Anzahl der Klans, in denen du schon einmal warst',
-					ES: 'Cantidad DE clanes EN los que has sido identificado.'
+					ES: 'Cantidad de clanes en los que has sido identificado.'
 				}
 			},
 			{
@@ -2750,9 +2750,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of clans this player has appeared in',
-			FR: 'Nombre DE clans dans lequel le joueur a été aperçu',
+			FR: 'Nombre de clans dans lequel le joueur a été aperçu',
 			DE: 'Anzahl der Klans, in denen du schon einmal warst',
-			ES: 'Cantidad DE clanes EN los que has sido identificado'
+			ES: 'Cantidad de clanes en los que has sido identificado'
 		}
 	},
 	[StatTracking.BEAUTY]: {
@@ -2777,9 +2777,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: "Number of Beauty Contest titles won by this player's dinoz.",
-					FR: 'Nombre DE titres DE beautés remportés par les Dinoz du joueur.',
+					FR: 'Nombre de titres de beauté remportés par les Dinoz du joueur.',
 					DE: 'Anzahl der von deinen Dinoz gewonnenen Schönheitstitel',
-					ES: 'Cantidad DE títulos DE belleza.'
+					ES: 'Cantidad de títulos de belleza.'
 				}
 			},
 			{
@@ -2825,9 +2825,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: "Number of Beauty Contest titles won by this player's dinoz",
-			FR: 'Nombre DE titres DE beautés remportés par les Dinoz du joueur',
+			FR: 'Nombre de titres de beauté remportés par les Dinoz du joueur',
 			DE: 'Anzahl der von deinen Dinoz gewonnenen Schönheitstitel',
-			ES: 'Cantidad DE títulos DE belleza'
+			ES: 'Cantidad de títulos de belleza'
 		}
 	},
 	[StatTracking.GDC_ATK]: {
@@ -2854,7 +2854,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Number of attacks carried out against enemy castles.',
 					FR: "Nombre d'attaques menées contre un château adverse.",
 					DE: 'So oft hast du ein gegnerisches Schloss angegriffen',
-					ES: 'Cantidad DE atacantes enviados al castillo enemigo.'
+					ES: 'Cantidad de atacantes enviados al castillo enemigo.'
 				}
 			},
 			{
@@ -2924,7 +2924,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Almighty Destroyer',
 					FR: 'Dieu destructeur',
 					DE: 'Gott der Zerstörung',
-					ES: 'Dios DE la Guerra'
+					ES: 'Dios de la Guerra'
 				}
 			}
 		],
@@ -2932,7 +2932,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Number of attacks carried out against enemy castles',
 			FR: "Nombre d'attaques menées contre un château adverse",
 			DE: 'So viele Male hast du ein gegnerisches Schloss angegriffen',
-			ES: 'Cantidad DE atacantes enviados al castillo enemigo'
+			ES: 'Cantidad de atacantes enviados al castillo enemigo'
 		}
 	},
 	[StatTracking.GDC_DEF]: {
@@ -2957,9 +2957,9 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'Number of times you have defended your castle.',
-					FR: 'Nombre DE fois où vous avez défendu votre château.',
+					FR: 'Nombre de fois où vous avez défendu votre château.',
 					DE: 'So viele Male hast du dein Schloss verteidigt',
-					ES: 'Cantidad DE veces que has defendido tu castillo.'
+					ES: 'Cantidad de veces que has defendido tu castillo.'
 				}
 			},
 			{
@@ -3035,9 +3035,9 @@ export const goals: Record<StatTracking, Goal> = {
 		],
 		description: {
 			EN: 'Number of times you have defended your castle',
-			FR: 'Nombre DE fois où vous avez défendu votre château',
+			FR: 'Nombre de fois où vous avez défendu votre château',
 			DE: 'So viele Male hast du dein Schloss verteidigt',
-			ES: 'Cantidad DE veces que has defendido tu castillo'
+			ES: 'Cantidad de veces que has defendido tu castillo'
 		}
 	},
 	[StatTracking.BGUM]: {
@@ -3062,7 +3062,7 @@ export const goals: Record<StatTracking, Goal> = {
 				},
 				description: {
 					EN: 'For those who are committed to making Dinoland an even better place!',
-					FR: 'Vous oeuvrez pour rendre le monde DE Dinoland encore meilleur !',
+					FR: 'Vous oeuvrez pour rendre le monde de Dinoland encore meilleur !',
 					DE: 'Du bist ein aktives Mitglieder der Dinoland-Community!',
 					ES: '¡Maestros como tú hacen que Dinoland sea cada vez mejor!'
 				}
@@ -3112,9 +3112,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: "Papy Joe's Twin",
-					FR: 'Jumeau DE Papy joe',
+					FR: 'Jumeau de Papy joe',
 					DE: 'Papy Joes Zwilling',
-					ES: 'Nieto DE Papy Jose'
+					ES: 'Nieto de Papy Jose'
 				}
 			},
 			{
@@ -3122,9 +3122,9 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: "Bao's Ancestor",
-					FR: 'Ancêtre DE Bao',
+					FR: 'Ancêtre de Bao',
 					DE: 'Vorfahre Baos',
-					ES: 'Ancestro DE Bao'
+					ES: 'Ancestro de Bao'
 				}
 			},
 			{
@@ -3142,16 +3142,16 @@ export const goals: Record<StatTracking, Goal> = {
 				points: 0,
 				title: {
 					EN: '6th Guardian of Dinoland',
-					FR: '6ème Gardien DE Dinoland',
+					FR: '6ème Gardien de Dinoland',
 					DE: '6. Wächter von Dinoland',
-					ES: '6to Guardián DE Dinoland'
+					ES: '6to Guardián de Dinoland'
 				}
 			}
 		],
 		description: {
 			EN: 'The most giving of Dinoz masters',
 			FR: 'La crême des maîtres Dinoz',
-			DE: 'Die Crème DE la Crème der Dinozmeister',
+			DE: 'Die Crème de la Crème der Dinozmeister',
 			ES: 'Aportes al sitio y a la comunidad'
 		}
 	},
@@ -3167,9 +3167,9 @@ export const goals: Record<StatTracking, Goal> = {
 		unlocks: [],
 		description: {
 			EN: 'Number of merguez sausages consumed',
-			FR: 'Nombre DE merguez consommées',
+			FR: 'Nombre de merguez consommées',
 			DE: 'Anzahl der verzehrten Merguez',
-			ES: 'Cantidad DE salchichas consumidas'
+			ES: 'Cantidad de salchichas consumidas'
 		}
 	},
 	[StatTracking.MEDAL_1]: {
@@ -3178,7 +3178,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Gold Medal',
 			FR: "Médaille d'or",
 			DE: 'Goldmedaille',
-			ES: 'Medalla dinolímpica DE oro'
+			ES: 'Medalla dinolímpica de oro'
 		},
 		rare: 1,
 		unlocks: [
@@ -3190,7 +3190,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Gold Medal',
 					FR: "Médaille d'or",
 					DE: 'Goldmedaille',
-					ES: 'Medallista olímpico DE oro'
+					ES: 'Medallista olímpico de oro'
 				},
 				description: {
 					EN: 'You finished first! Congratulations!',
@@ -3213,7 +3213,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'Silver medal',
 			FR: "Médaille d'argent",
 			DE: 'Silbermedaille',
-			ES: 'Medalla dinolímpica DE plata'
+			ES: 'Medalla dinolímpica de plata'
 		},
 		rare: 1,
 		unlocks: [
@@ -3225,7 +3225,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Silver Medal',
 					FR: "Médaille d'argent",
 					DE: 'Silbermedaille',
-					ES: 'Medallista olímpico DE plata'
+					ES: 'Medallista olímpico de plata'
 				},
 				description: {
 					EN: 'You finished second! Bravo!',
@@ -3239,16 +3239,16 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'The Silver Medallist in the 1st Dinolympic Games!',
 			FR: 'Vous avez fini second !',
 			DE: 'Bravo, ihr seid zweiter',
-			ES: '¡Segundo lugar EN los 1ros. Juegos Dinolímpicos Internacionales!'
+			ES: '¡Segundo lugar en los 1ros. Juegos Dinolímpicos Internacionales!'
 		}
 	},
 	[StatTracking.MEDAL_3]: {
 		id: StatTracking.MEDAL_3,
 		name: {
 			EN: 'Bronze Medal',
-			FR: 'Médaille DE bronze',
+			FR: 'Médaille de bronze',
 			DE: 'Bronzemedaille',
-			ES: 'Medalla dinolímpica DE bronce'
+			ES: 'Medalla dinolímpica de bronce'
 		},
 		rare: 1,
 		unlocks: [
@@ -3258,15 +3258,15 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_medbro.gif',
 				title: {
 					EN: 'Bronze Medal',
-					FR: 'Médaille DE bronze',
+					FR: 'Médaille de bronze',
 					DE: 'Bronzemedaille',
-					ES: 'Medallista olímpico DE bronce'
+					ES: 'Medallista olímpico de bronce'
 				},
 				description: {
 					EN: 'You finished third! Great performance!',
 					FR: "Vous avez fini troisième ! C'est une très belle performance !",
 					DE: 'Ihr seid auf Rang drei. Super Leistung!',
-					ES: '¡Tercer lugar EN los 1ros. Juegos Dinolímpicos Internacionales!'
+					ES: '¡Tercer lugar en los 1ros. Juegos Dinolímpicos Internacionales!'
 				}
 			}
 		],
@@ -3274,7 +3274,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'The Bronze medal winner in the 1st Dinolympic Games!',
 			FR: 'Vous avez fini troisième !',
 			DE: 'Ihr seid auf Rang drei!',
-			ES: '¡Tercer lugar EN los 1ros. Juegos Dinolímpicos Internacionales!'
+			ES: '¡Tercer lugar en los 1ros. Juegos Dinolímpicos Internacionales!'
 		}
 	},
 	[StatTracking.MEDAL_4]: {
@@ -3293,7 +3293,7 @@ export const goals: Record<StatTracking, Goal> = {
 				icon: 'r_medpla.gif',
 				title: {
 					EN: 'Dinolympic Medal',
-					FR: 'Médaille DE participation',
+					FR: 'Médaille de participation',
 					DE: 'Teilnahmemedaille',
 					ES: 'Atleta olímpico'
 				},
@@ -3301,7 +3301,7 @@ export const goals: Record<StatTracking, Goal> = {
 					EN: 'Dinolympic Athlete - be proud of your achievements!',
 					FR: 'Vous avez réussi à vous classer parmi les meilleurs participants !',
 					DE: 'Ihr gehört zu den besten Teilnehmern!!',
-					ES: '¡Te colocaste EN el Top 10 DE nuestro servidor EN los 1ros. Juegos Dinolímpicos!'
+					ES: '¡Te colocaste en el Top 10 DE nuestro servidor en los 1ros. Juegos Dinolímpicos!'
 				}
 			}
 		],
@@ -3309,7 +3309,7 @@ export const goals: Record<StatTracking, Goal> = {
 			EN: 'You were ranked amongst the top Dinolympic competitors!',
 			FR: 'Vous avez réussi à vous classer parmi les meilleurs participants !',
 			DE: 'Ihr gehört zu den besten Teilnehmern!',
-			ES: '¡Te colocaste EN el Top 10 DE nuestro servidor EN los 1ros. Juegos Dinolímpicos!'
+			ES: '¡Te colocaste en el Top 10 de nuestro servidor en los 1ros. Juegos Dinolímpicos!'
 		}
 	},
 	[StatTracking.LEVELUP_1]: {

--- a/packages/core/src/models/place/placeListv2.ts
+++ b/packages/core/src/models/place/placeListv2.ts
@@ -670,7 +670,7 @@ export const placeListv2 = definePlaces({
 		moves: [
 			{ target: PlaceEnum.PORTAIL },
 			{ target: PlaceEnum.TOUR_SOMBRE },
-			{ target: PlaceEnum.RETOUR_SURFACE /*, condition: 'active(gulom)'*/ },
+			{ target: PlaceEnum.RETOUR_SURFACE, condition: 'active(gulom)' },
 			{ target: PlaceEnum.DARK_FAKE, condition: 'curmission(ouestu)|curmission(lumi)|curmission(truci2)|fx(morsso)' }
 		],
 		background: 's_dkChutes'


### PR DESCRIPTION
- Suppression de compte : Anonymisation des données (le pseudo devient "Inconnu" dans le marché, la messagerie et les clans) au lieu d'une suppression en cascade pour préserver l'historique du jeu.
- Reset de compte : Ajout de la remise à zéro complète pour éviter les exploits (nettoyage de l'épargne en banque, des réincarnations, et des compétences uniques/découvertes). Le compte repart seulement avec 100 000 d'or.
- UI : Quelques ajustements visuels (marges de l'or et espacements des noms au marché).
- Fix : Harmonisation des erreurs (userNotFound) et ajout des clés i18n FR.