### PR TITLE
Feat: Account reset & deletion overhaul- #459

### DIFF
--- a/app/client/src/components/account/ProfileGame.vue
+++ b/app/client/src/components/account/ProfileGame.vue
@@ -92,29 +92,19 @@
 				{{ $t(`accountPage.options.title`) }}
 				<img :src="getImgURL('icons', 'info_button')" alt="info_button" />
 			</h3>
-			<dl>
-				<DZButton @click="openPasswordModal">{{ $t(`accountPage.options.mdp`) }}</DZButton>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-				<dt>
-					{{ $t(`accountPage.options.todo`) }}
-				</dt>
-				<dd></dd>
-			</dl>
 			<div class="buttonLand" v-if="isMyAccount()">
-				<!--<DZButton href="" @click="resetAccount()">{{ $t(`myAccount.options.reset`) }}</DZButton>-->
-				<DZButton class="bSmall" back @click="option = false">{{ $t(`accountPage.options.retour`) }}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openPasswordModal">{{
+					$t(`accountPage.options.mdp`)
+				}}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openResetModal">{{
+					$t(`accountPage.options.reset`)
+				}}</DZButton>
+				<DZButton class="no-first-letter btn-wide" @click="openDeleteModal">{{
+					$t(`accountPage.options.delete`)
+				}}</DZButton>
+				<DZButton class="bSmall no-first-letter" back @click="option = false">{{
+					$t(`accountPage.options.retour`)
+				}}</DZButton>
 			</div>
 		</div>
 	</transition>
@@ -125,6 +115,16 @@
 		:with-old-password="true"
 		@close="closePasswordModal"
 		@submit="submitPasswordChange"
+	/>
+	<ConfirmActionModal
+		v-if="confirmActionModalOpen"
+		:title="confirmActionConfig.title"
+		:description="confirmActionConfig.description"
+		:actionType="confirmActionConfig.actionType"
+		:loading="confirmActionLoading"
+		:error="confirmActionError"
+		@close="closeConfirmActionModal"
+		@submit="submitConfirmAction"
 	/>
 </template>
 
@@ -159,13 +159,22 @@ export default defineComponent({
 			//dinozStore: dinozStore()
 			passwordModalOpen: false,
 			passwordLoading: false,
-			passwordError: null as string | null
+			passwordError: null as string | null,
+			confirmActionModalOpen: false,
+			confirmActionLoading: false,
+			confirmActionError: null as string | null,
+			confirmActionConfig: {
+				title: '',
+				description: '',
+				actionType: 'delete' as 'delete' | 'reset'
+			}
 		};
 	},
 	components: {
 		DZUser: defineAsyncComponent(() => import('../utils/DZUser.vue')),
 		DZButton,
-		ChangePasswordModal
+		ChangePasswordModal,
+		ConfirmActionModal: defineAsyncComponent(() => import('../modal/ConfirmActionModal.vue'))
 	},
 	props: {
 		profile: {
@@ -223,6 +232,59 @@ export default defineComponent({
 				errorHandler.handle(err, this.$toast);
 			} finally {
 				this.passwordLoading = false;
+			}
+		},
+		openResetModal() {
+			this.confirmActionConfig = {
+				title: this.$t('accountPage.options.resetTitle'),
+				description: this.$t('accountPage.options.resetDescription'),
+				actionType: 'reset'
+			};
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = true;
+		},
+		openDeleteModal() {
+			this.confirmActionConfig = {
+				title: this.$t('accountPage.options.deleteTitle'),
+				description: this.$t('accountPage.options.deleteDescription'),
+				actionType: 'delete'
+			};
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = true;
+		},
+		closeConfirmActionModal() {
+			if (this.confirmActionLoading) return;
+			this.confirmActionError = null;
+			this.confirmActionModalOpen = false;
+		},
+		async submitConfirmAction(payload: { password: string }) {
+			this.confirmActionError = null;
+			this.confirmActionLoading = true;
+			try {
+				if (this.confirmActionConfig.actionType === 'delete') {
+					await UserService.deleteAccount(payload.password);
+				} else {
+					await UserService.resetAccount(payload.password);
+				}
+				this.confirmActionModalOpen = false;
+
+				// Clear the user store to trigger a logout state
+				this.uStore.clearUser();
+				// Redirect to home
+				window.location.href = '/';
+			} catch (err: any) {
+				const errMsg = err?.response?.data?.message || err?.message;
+				if (errMsg === 'userInClan') {
+					this.confirmActionError =
+						"Vous ne pouvez pas faire ça car vous êtes dans un clan. Veuillez d'abord le quitter.";
+				} else if (errMsg === 'invalidConfirmation') {
+					this.confirmActionError = 'Mot de passe incorrect.';
+				} else {
+					errorHandler.handle(err, this.$toast);
+					this.confirmActionError = 'Une erreur est survenue.';
+				}
+			} finally {
+				this.confirmActionLoading = false;
 			}
 		},
 		startProfileTextEdit() {
@@ -407,8 +469,22 @@ export default defineComponent({
 	margin-bottom: auto;
 	align-items: center;
 	margin-bottom: 5px;
-	* {
+	> * {
 		margin-bottom: 5px;
+	}
+}
+.btn-wide {
+	width: auto !important;
+	min-width: 145px;
+	padding: 0 15px;
+	background-size: 100% 100% !important;
+}
+.no-first-letter {
+	&::first-letter {
+		color: inherit !important;
+	}
+	:deep(span::first-letter) {
+		color: inherit !important;
 	}
 }
 .tinybutton {

--- a/app/client/src/components/common/LeftPanel.vue
+++ b/app/client/src/components/common/LeftPanel.vue
@@ -14,10 +14,8 @@
 <template>
 	<div id="accountList">
 		<div class="money">
-			<span class="moneyValue">
-				{{ beautifulNumber(displayedAmount) }}
-			</span>
-			<img :src="walletIcon" :alt="selectedWallet" />
+			<span class="moneyValue">{{ beautifulNumber(displayedAmount) }}</span>
+			<img class="wallet-icon" :src="walletIcon" :alt="selectedWallet" />
 		</div>
 		<DZSelect id="wallet-select" class="moneySelect" v-model="selectedWallet" :options="walletOptions" />
 		<div class="iconMenu">
@@ -294,6 +292,7 @@ export default defineComponent({
 		font-weight: bold;
 		img {
 			vertical-align: -5%;
+			margin-left: 4px;
 		}
 	}
 	.moneySelect {

--- a/app/client/src/components/market/OfferLine.vue
+++ b/app/client/src/components/market/OfferLine.vue
@@ -61,11 +61,9 @@
 			<p v-if="bestBid">
 				<span>{{ $t('market.highestBid') }}:</span>
 				<span>
-					<span class="bid-value">{{ bestBid.value }}</span>
-					<img :src="getImgURL('icons', 'ticket')" />
-					<span>{{ $t('market.by') }} </span>
-					<DZUser v-if="bestBid.user" :user="bestBid.user" />
-					<span v-else>{{ bestBid.userName }}</span>
+					<span class="bid-value">{{ bestBid.value }}</span
+					><img :src="getImgURL('icons', 'ticket')" /><span>{{ $t('market.by') }}</span
+					>&nbsp;<DZUser v-if="bestBid.user" :user="bestBid.user" /><span v-else>{{ bestBid.userName }}</span>
 				</span>
 			</p>
 			<p v-else>

--- a/app/client/src/components/modal/ConfirmActionModal.vue
+++ b/app/client/src/components/modal/ConfirmActionModal.vue
@@ -1,0 +1,152 @@
+<template>
+	<div class="modal-background">
+		<div class="password-modal">
+			<h3>{{ title }}</h3>
+			<p class="description">{{ description }}</p>
+
+			<div class="field">
+				<label for="passwordInput">{{ labelText }}</label>
+				<DZInput
+					id="passwordInput"
+					v-model="form.password"
+					type="password"
+					:placeholder="$t('modal.confirmAction.passwordPlaceholder')"
+					autocomplete="off"
+				/>
+			</div>
+
+			<p v-if="localError" class="password-error">{{ localError }}</p>
+			<p v-else-if="error" class="password-error">{{ error }}</p>
+
+			<div class="buttonLand">
+				<DZButton class="bSmall no-first-letter" @click="submit">
+					{{ loading ? $t('modal.confirmAction.loading') : $t('modal.confirmAction.confirm') }}
+				</DZButton>
+				<DZButton class="bSmall no-first-letter" back @click="$emit('close')">{{
+					$t('modal.confirmAction.cancel')
+				}}</DZButton>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script setup lang="ts">
+import { reactive, ref, computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import DZInput from '../utils/DZInput.vue';
+import DZButton from '../utils/DZButton.vue';
+
+const { t } = useI18n();
+
+const props = withDefaults(
+	defineProps<{
+		title: string;
+		description: string;
+		label?: string;
+		loading?: boolean;
+		error?: string | null;
+		actionType?: 'reset' | 'delete';
+	}>(),
+	{
+		label: '',
+		loading: false,
+		error: null,
+		actionType: 'delete'
+	}
+);
+
+const labelText = computed(() => props.label || t('modal.confirmAction.label'));
+
+const emit = defineEmits<{
+	close: [];
+	submit: [
+		payload: {
+			password: string;
+		}
+	];
+}>();
+
+const localError = ref<string | null>(null);
+
+const form = reactive({
+	password: ''
+});
+
+function submit() {
+	localError.value = null;
+
+	if (!form.password) {
+		localError.value = t('modal.confirmAction.passwordRequired');
+		return;
+	}
+
+	emit('submit', { password: form.password });
+}
+</script>
+
+<style scoped lang="scss">
+@use 'sass:color';
+.modal-background {
+	position: absolute;
+	background: color.adjust(#09092d, $alpha: -0.4);
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	z-index: 999;
+	transition: all 0.3s;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-direction: column;
+}
+.password-modal {
+	width: min(420px, calc(100% - 32px));
+	background-color: #ecbd84;
+	border: 2px solid #bc683c;
+	padding: 20px;
+	color: #7b3f22;
+	h3 {
+		margin-top: 0;
+		color: #9a4029;
+	}
+	.field {
+		display: flex;
+		flex-direction: column;
+		gap: 4px;
+		margin-bottom: 12px;
+	}
+	:deep(input) {
+		border: none;
+		background-color: #ae6139;
+		color: #ffee92;
+		padding: 6px;
+	}
+	:deep(input:focus) {
+		background-color: #9a4029;
+		outline: none;
+	}
+}
+.description {
+	margin-bottom: 20px;
+	font-size: 14px;
+	color: #7b3f22;
+}
+.password-error {
+	color: #8f1d12;
+	font-weight: bold;
+}
+.buttonLand {
+	display: flex;
+	justify-content: space-around;
+	margin-top: 15px;
+}
+.no-first-letter {
+	&::first-letter {
+		color: inherit !important;
+	}
+	:deep(span::first-letter) {
+		color: inherit !important;
+	}
+}
+</style>

--- a/app/client/src/i18n/locales/FR.json
+++ b/app/client/src/i18n/locales/FR.json
@@ -581,6 +581,14 @@
 				"passwordMismatch": "Les nouveaux mots de passe ne correspondent pas."
 			}
 		},
+		"confirmAction": {
+			"label": "Veuillez entrer votre mot de passe pour confirmer :",
+			"passwordPlaceholder": "Mot de passe",
+			"loading": "Chargement...",
+			"confirm": "Confirmer",
+			"cancel": "Annuler",
+			"passwordRequired": "Veuillez entrer votre mot de passe pour confirmer."
+		},
 		"modif": "Modification...",
 		"valid": "Valider",
 		"close": "Fermer",
@@ -681,7 +689,7 @@
 		"Missing_device_cookie": "Impossible d’identifier votre navigateur. Veuillez autoriser les cookies et réessayer.",
 		"Too_many_accounts_created_from_this_device_this_month": "Trop de comptes ont été créés depuis ce navigateur ce mois-ci. Veuillez réessayer le mois prochain.",
 		"Too_many_accounts_created_from_this_network_this_month": "Trop de comptes ont été créés depuis ce réseau ce mois-ci. Veuillez réessayer le mois prochain.",
-		"userNotFound": "Le joueur {userId} n'a pas été trouvé.",
+		"userNotFound": "Le joueur {userId} a été supprimé ou n'existe plus.",
 		"dinozNotFound": "Le Dinoz {dinozId} n'a pas été trouvé.",
 		"dinozDoesNotBelongToUser": "Le Dinoz {dinozId} n'appartient pas au joueur {userId}.",
 		"invalidId": "L'id est invalide",
@@ -813,6 +821,17 @@
 		"userTitle": "Joueur : {name}",
 		"noDescription": "Aucune description sur ce profil...",
 		"editProfile": "Editer mon profil",
+		"options": {
+			"title": "Options du compte",
+			"mdp": "Modifier le MDP",
+			"reset": "Recommencer le compte",
+			"delete": "Supprimer le compte",
+			"resetTitle": "Recommencer le compte",
+			"resetDescription": "Êtes-vous sûr de vouloir tout recommencer ? Vous conserverez votre nom, votre description, votre avatar et votre messagerie. Cependant, TOUS VOS DINOZ, VOTRE INVENTAIRE ET VOTRE ARGENT SERONT DÉFINITIVEMENT PERDUS. Vous recommencerez l'aventure à zéro avec 100 000 pièces d'or.",
+			"deleteTitle": "Supprimer le compte",
+			"deleteDescription": "ATTENTION : Êtes-vous absolument sûr de vouloir supprimer votre compte ? Cette action effacera DÉFINITIVEMENT votre progression, vos dinoz, votre inventaire et votre profil. CETTE ACTION EST IRRÉVERSIBLE.",
+			"retour": "Retour"
+		},
 		"changeAvatar": "Changer l'avatar",
 		"save": "Sauvegarder le profil",
 		"cancel": "Annuler les changements",
@@ -830,13 +849,6 @@
 		"editAccount": "Modifier le profil",
 		"edit": "Editer",
 		"descriptionUpdated": "Description mise à jour !",
-		"options": {
-			"title": "Options du compte",
-			"mdp": "Modifier le MDP",
-			"todo": "à venir...",
-			"reset": "Réinitialiser le compte",
-			"retour": "Retour"
-		},
 		"goals": {
 			"title": "Statistiques DinoRPG",
 			"points": "points",
@@ -6370,7 +6382,6 @@
 				},
 				"end": "Sahalami ne terrorisera plus personne. Reste à élucider le mystère de ce pendentif..."
 			},
-
 			"penden": {
 				"name": "Un collier bien mystérieux",
 				"begin": "Le pendentif en forme de Couperet de cuisine trouvé sur Sahalami est quand même très étrange... Vous devriez mener l'enquête à son sujet.",
@@ -6386,7 +6397,6 @@
 				},
 				"end": "Vous avez obtenu les informations qu'il vous fallait. "
 			},
-
 			"hunt1": {
 				"name": "On recherche: Tripou le mou",
 				"begin": "« ON RECHERCHE : Tripou, le pillard mou des nuits sans lune. Les derniers rapports font état d'une attaque au pied de la Dévoreuse du nord. Mission très dangereuse, belle récompense à prévoir. »",
@@ -6442,7 +6452,6 @@
 				},
 				"end": "Vous avez réussi à vaincre Tripou ! Félicitations !"
 			},
-
 			"hunt2": {
 				"name": "On recherche: Boukané l'intuable",
 				"begin": "« ON RECHERCHE : Boukané, l'intuable tortionnaire des abîmes insondables ! Il se terre dans son repaire en Extrême Occident, mission hautement périlleuse ! »",
@@ -6475,7 +6484,6 @@
 				},
 				"end": "Vous avez déjoué les plans de Boukané. De toutes évidences, il s'apprêtait à attaquer la Citadelle par son point faible..."
 			},
-
 			"hunt3": {
 				"name": "On recherche: Cervelah l'empoisonneur",
 				"begin": "« ON RECHERCHE : Cervelah, l'empoisonneur verdâtre. Grand, brun, porte une capuche et est toujours accompagné de Pikouz, son fidèle scorpwink. Individu extrêmement hostile. Forte prime offerte par le Consortium des Filous Associés ! Contactez Aboul Tonhor, marchand aux Pylônes. »",

--- a/app/client/src/services/user.service.ts
+++ b/app/client/src/services/user.service.ts
@@ -72,5 +72,15 @@ export const UserService = {
 		return api.post<GameRulesAcceptance>('/users/me/rules/accept', {
 			version
 		});
+	},
+	deleteAccount(password: string): Promise<void> {
+		return api.delete<void>('/users/me/delete', {
+			data: { password }
+		});
+	},
+	resetAccount(password: string): Promise<void> {
+		return api.post<void>('/users/me/reset', {
+			password
+		});
 	}
 };

--- a/app/server/src/Market/Helpers/cleanMarketForAccountDeletion.helper.ts
+++ b/app/server/src/Market/Helpers/cleanMarketForAccountDeletion.helper.ts
@@ -1,0 +1,48 @@
+import { MoneyType, Prisma } from '../../../../prisma/index.js';
+
+export async function cleanMarketForAccountDeletionTx(tx: Prisma.TransactionClient, userId: string) {
+	// 1. Gérer les offres dont l'utilisateur est le vendeur
+	const userOffers = await tx.offer.findMany({
+		where: {
+			sellerId: userId,
+			status: 'ONGOING'
+		},
+		include: {
+			bids: true
+		}
+	});
+
+	for (const offer of userOffers) {
+		// Rembourser les enchérisseurs (s'ils existent)
+		for (const bid of offer.bids) {
+			if (bid.userId) {
+				await tx.userWallet.updateMany({
+					where: {
+						userId: bid.userId,
+						type: MoneyType.TREASURE_TICKET
+					},
+					data: {
+						amount: { increment: bid.value }
+					}
+				});
+			}
+		}
+
+		// Supprimer l'offre (ce qui supprimera aussi les bids associés via onDelete: Cascade)
+		await tx.offer.delete({
+			where: { id: offer.id }
+		});
+	}
+
+	// 2. Gérer les enchères placées par l'utilisateur sur d'autres offres
+	// Le simple fait de supprimer ses enchères rend la main à l'enchérisseur précédent.
+	// Son argent investi est détruit (car son compte est supprimé/réinitialisé).
+	await tx.offerBid.deleteMany({
+		where: {
+			userId: userId,
+			offer: {
+				status: 'ONGOING'
+			}
+		}
+	});
+}

--- a/app/server/src/User/Controller/deleteUser.controller.ts
+++ b/app/server/src/User/Controller/deleteUser.controller.ts
@@ -1,0 +1,77 @@
+import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
+import bcrypt from 'bcrypt';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { ACCESS_TOKEN_COOKIE, authCookieBaseOptions } from '../../config/cookie.js';
+import { cleanMarketForAccountDeletionTx } from '../../Market/Helpers/cleanMarketForAccountDeletion.helper.js';
+import { prisma } from '../../prisma.js';
+
+export async function deleteUser(req: FastifyRequest<{ Body: { password: string } }>, reply: FastifyReply) {
+	const userId = req.user.id;
+	const password = req.body?.password;
+
+	if (!password) {
+		throw new ExpectedError('invalidConfirmation');
+	}
+
+	await prisma.$transaction(async tx => {
+		const user = await tx.user.findUnique({
+			where: { id: userId },
+			include: { ClanMember: true, leaderOf: true }
+		});
+
+		if (!user) {
+			throw new ExpectedError('userNotFound');
+		}
+
+		const isMatch = await bcrypt.compare(password, user.password);
+		if (!isMatch) {
+			throw new ExpectedError('invalidConfirmation');
+		}
+
+		if (user.ClanMember || user.leaderOf) {
+			throw new ExpectedError('userInClan');
+		}
+
+		// 1. Nettoyer le marché
+		await cleanMarketForAccountDeletionTx(tx, userId);
+
+		// 2. Nettoyage manuel des tables sans onDelete: Cascade
+		await tx.userWallet.deleteMany({ where: { userId } });
+		await tx.userProfile.deleteMany({ where: { userId } });
+		await tx.ranking.deleteMany({ where: { userId } });
+		await tx.devourerControl.deleteMany({ where: { userId } });
+		await tx.clanJoinRequest.deleteMany({ where: { userId } });
+
+		// 3. Anonymiser les traces du joueur (conversations, clan, marché)
+		await tx.message.updateMany({
+			where: { senderId: userId },
+			data: { senderNameSnapshot: 'inconnu' }
+		});
+		await tx.participant.updateMany({
+			where: { userId: userId },
+			data: { userNameSnapshot: 'inconnu' }
+		});
+		await tx.clanMessage.updateMany({
+			where: { authorId: userId },
+			data: { authorName: 'inconnu' }
+		});
+		await tx.offer.updateMany({
+			where: { sellerId: userId },
+			data: { sellerName: 'inconnu' }
+		});
+		await tx.offerBid.updateMany({
+			where: { userId: userId },
+			data: { userName: 'inconnu' }
+		});
+
+		// 4. Supprimer le User (ce qui supprimera le reste en cascade ou mettra SetNull selon les relations)
+		await tx.user.delete({
+			where: { id: userId }
+		});
+	});
+
+	// Déconnexion
+	reply.clearCookie(ACCESS_TOKEN_COOKIE, authCookieBaseOptions);
+	return reply.send({ ok: true });
+}

--- a/app/server/src/User/Controller/money.controller.ts
+++ b/app/server/src/User/Controller/money.controller.ts
@@ -31,17 +31,22 @@ export async function addMoney(userId: string, money: number) {
 }
 
 export async function addTreasureTicket(userId: string, money: number) {
-	return prisma.userWallet.update({
+	return prisma.userWallet.upsert({
 		where: {
 			userId_type: {
 				userId,
 				type: MoneyType.TREASURE_TICKET
 			}
 		},
-		data: {
+		update: {
 			amount: {
 				increment: money
 			}
+		},
+		create: {
+			userId,
+			type: MoneyType.TREASURE_TICKET,
+			amount: money
 		}
 	});
 }

--- a/app/server/src/User/Controller/resetUser.controller.ts
+++ b/app/server/src/User/Controller/resetUser.controller.ts
@@ -49,12 +49,24 @@ export async function resetUser(req: FastifyRequest<{ Body: { password: string }
 		await tx.userDinozShop.deleteMany({ where: { userId } });
 		await tx.clanJoinRequest.deleteMany({ where: { userId } });
 		await tx.devourerControl.deleteMany({ where: { userId } });
+		await tx.bankSaving.deleteMany({ where: { userId } });
 
-		// 3. Réinitialiser les compteurs du User
+		// 3. Réinitialiser les compteurs et compétences uniques du User
 		await tx.user.update({
 			where: { id: userId },
 			data: {
-				devourerAttacksLeft: 3
+				devourerAttacksLeft: 3,
+				leader: false,
+				engineer: false,
+				cooker: false,
+				shopKeeper: false,
+				merchant: false,
+				priest: false,
+				teacher: false,
+				matelasseur: false,
+				messie: false,
+				discoveredSkills: [],
+				keepSeedReincarnationCount: 0
 			}
 		});
 		await tx.ranking.update({

--- a/app/server/src/User/Controller/resetUser.controller.ts
+++ b/app/server/src/User/Controller/resetUser.controller.ts
@@ -1,0 +1,92 @@
+import { ExpectedError } from '@dinorpg/core/models/utils/expectedError.js';
+import bcrypt from 'bcrypt';
+import type { FastifyReply, FastifyRequest } from 'fastify';
+
+import { ACCESS_TOKEN_COOKIE, authCookieBaseOptions } from '../../config/cookie.js';
+import gameConfig from '../../config/game.config.js';
+import { cleanMarketForAccountDeletionTx } from '../../Market/Helpers/cleanMarketForAccountDeletion.helper.js';
+import { prisma } from '../../prisma.js';
+
+export async function resetUser(req: FastifyRequest<{ Body: { password: string } }>, reply: FastifyReply) {
+	const userId = req.user.id;
+	const password = req.body?.password;
+
+	if (!password) {
+		throw new ExpectedError('invalidConfirmation');
+	}
+
+	await prisma.$transaction(async tx => {
+		const user = await tx.user.findUnique({
+			where: { id: userId },
+			include: { ClanMember: true, leaderOf: true }
+		});
+
+		if (!user) {
+			throw new ExpectedError('userNotFound');
+		}
+
+		const isMatch = await bcrypt.compare(password, user.password);
+		if (!isMatch) {
+			throw new ExpectedError('invalidConfirmation');
+		}
+
+		if (user.ClanMember || user.leaderOf) {
+			throw new ExpectedError('userInClan');
+		}
+
+		// 1. Nettoyer le marché
+		await cleanMarketForAccountDeletionTx(tx, userId);
+
+		// 2. Supprimer manuellement l'inventaire complet, les dinoz, la boutique, etc.
+		// Attention : L'ordre est important si certaines contraintes existent.
+		await tx.dinoz.deleteMany({ where: { userId } });
+		await tx.userItems.deleteMany({ where: { userId } });
+		await tx.userIngredients.deleteMany({ where: { userId } });
+		await tx.userGather.deleteMany({ where: { userId } });
+		await tx.userRewards.deleteMany({ where: { userId } });
+		await tx.userScenario.deleteMany({ where: { userId } });
+		await tx.userTracking.deleteMany({ where: { userId } });
+		await tx.userDinozShop.deleteMany({ where: { userId } });
+		await tx.clanJoinRequest.deleteMany({ where: { userId } });
+		await tx.devourerControl.deleteMany({ where: { userId } });
+
+		// 3. Réinitialiser les compteurs du User
+		await tx.user.update({
+			where: { id: userId },
+			data: {
+				devourerAttacksLeft: 3
+			}
+		});
+		await tx.ranking.update({
+			where: { userId },
+			data: {
+				dinozCount: 0,
+				points: 0,
+				average: 0,
+				completion: 0,
+				dojo: 0
+			}
+		});
+
+		// 4. Réinitialiser les portefeuilles (seulement de l'or pour le reset)
+		await tx.userWallet.deleteMany({ where: { userId } });
+		await tx.userWallet.createMany({
+			data: [
+				{
+					userId,
+					type: 'GOLD',
+					amount: 100000
+				},
+				{
+					userId,
+					type: 'TREASURE_TICKET',
+					amount: 0
+				}
+			]
+		});
+	});
+
+	// Déconnexion
+	reply.clearCookie(ACCESS_TOKEN_COOKIE, authCookieBaseOptions);
+	return reply.send({ ok: true });
+}

--- a/app/server/src/User/Controller/toolTipInfosUser.controller.ts
+++ b/app/server/src/User/Controller/toolTipInfosUser.controller.ts
@@ -9,7 +9,7 @@ export async function userToolTip(req: FastifyRequest) {
 	const user = await getToolTipInfos(id);
 
 	if (!user) {
-		throw new ExpectedError(`Missing user.`);
+		throw new ExpectedError('userNotFound');
 	}
 
 	return user;

--- a/app/server/src/User/Routes/user.routes.ts
+++ b/app/server/src/User/Routes/user.routes.ts
@@ -3,9 +3,11 @@ import { FastifyInstance } from 'fastify';
 import { acceptGameRules } from '../Controller/acceptGameRules.controller.js';
 import { checkNameUser } from '../Controller/checkNameUser.controller.js';
 import { createUser } from '../Controller/createUser.controller.js';
+import { deleteUser } from '../Controller/deleteUser.controller.js';
 import { loginUser } from '../Controller/loginUser.controller.js';
 import { logoutUser } from '../Controller/logoutUser.controller.js';
 import { meUser } from '../Controller/meUser.controller.js';
+import { resetUser } from '../Controller/resetUser.controller.js';
 import { searchUsersByName } from '../Controller/searchUsersByName.controller.js';
 import { userToolTip } from '../Controller/toolTipInfosUser.controller.js';
 import {
@@ -17,6 +19,7 @@ import {
 import {
 	acceptGameRulesSchema,
 	changeUserPasswordSchema,
+	confirmActionSchema,
 	createUserResponseSchema,
 	createUserSchema,
 	loginResponseSchema,
@@ -73,6 +76,30 @@ export async function userRoutes(app: FastifyInstance) {
 			}
 		},
 		changeUserPassword
+	);
+
+	app.delete(
+		'/me/delete',
+		{
+			preHandler: [app.authenticate],
+			schema: {
+				tags: ['Users'],
+				body: confirmActionSchema
+			}
+		},
+		deleteUser
+	);
+
+	app.post(
+		'/me/reset',
+		{
+			preHandler: [app.authenticate],
+			schema: {
+				tags: ['Users'],
+				body: confirmActionSchema
+			}
+		},
+		resetUser
 	);
 	// Check name of account creation
 	app.get(

--- a/app/server/src/User/Schema/user.schema.ts
+++ b/app/server/src/User/Schema/user.schema.ts
@@ -90,3 +90,4 @@ export const changeUserPasswordSchema = z
 	});
 
 export type ChangeUserPasswordInput = z.infer<typeof changeUserPasswordSchema>;
+export const confirmActionSchema = z.object({ password: z.string() });


### PR DESCRIPTION
- Suppression de compte : Anonymisation des données (le pseudo devient "Inconnu" dans le marché, la messagerie et les clans) au lieu d'une suppression en cascade pour préserver l'historique du jeu.
- Reset de compte : Ajout de la remise à zéro complète pour éviter les exploits (nettoyage de l'épargne en banque, des réincarnations, et des compétences uniques/découvertes). Le compte repart seulement avec 100 000 d'or.
- UI : Quelques ajustements visuels (marges de l'or et espacements des noms au marché).
- Fix : Harmonisation des erreurs (userNotFound) et ajout des clés i18n FR.