### PR TITLE
chore(deps): bump changesets cli to v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
 	"keywords": [],
 	"packageManager": "pnpm@10.12.1",
 	"devDependencies": {
-		"@changesets/cli": "^2.31.1",
+		"@changesets/cli": "^3.0.1",
 		"@commitlint/cli": "^21.2.1",
 		"@commitlint/config-conventional": "^21.2.0",
 		"@types/node": "^25.6.0",


### PR DESCRIPTION
Test PR created from ChatGPT via the GitHub connector.

Changes:
- bump `@changesets/cli` from `^2.31.1` to `^3.0.1` in the root `package.json`

Note: this intentionally leaves the lockfile unchanged for this connector write test.